### PR TITLE
Fix: Allocating new pod for failed pods in perodic update every loop

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -172,7 +172,7 @@ func (d *daemon) AddPeriodicUpdate() {
 			allocatedGuid, err := utils.GetPodNetworkGuid(network)
 			if err == nil {
 				// User allocated guid manually
-				if err = d.guidPool.AllocateGUID(string(pod.UID)+networkName, allocatedGuid); err != nil {
+				if err = d.guidPool.AllocateGUID(pod.UID, networkName, allocatedGuid); err != nil {
 					glog.Errorf("AddPeriodicUpdate(): %v", err)
 					continue
 				}
@@ -183,18 +183,30 @@ func (d *daemon) AddPeriodicUpdate() {
 					continue
 				}
 			} else {
-				allocatedGuid, err = d.guidPool.GenerateGUID("")
+				guidAddr, err = d.guidPool.GenerateGUID()
 				if err != nil {
 					glog.Error(err)
 					continue
 				}
-
-				if err = utils.SetPodNetworkGuid(network, allocatedGuid); err != nil {
-					glog.Errorf("AddPeriodicUpdate(): failed to set pod networkName annotation guid with error: %v ", err)
+				allocatedGuid = guidAddr.String()
+				if guidErr := d.guidPool.AllocateGUID(pod.UID, networkName, allocatedGuid); guidErr != nil {
+					glog.Errorf("AddPeriodicUpdate(): %v", guidErr)
 					continue
 				}
 
-				guidAddr, _ = net.ParseMAC(allocatedGuid)
+				if err = utils.SetPodNetworkGuid(network, allocatedGuid); err != nil {
+					glog.Errorf("AddPeriodicUpdate(): failed to set pod network guid with error: %v ", err)
+					continue
+				}
+
+				netAnnotations, err := json.Marshal(networks)
+				if err != nil {
+					glog.Warningf("AddPeriodicUpdate(): failed to dump networks %+v of pod into json with error: %v",
+						networks, err)
+					continue
+				}
+
+				pod.Annotations[v1.NetworkAttachmentAnnot] = string(netAnnotations)
 			}
 
 			guidList = append(guidList, guidAddr)

--- a/pkg/guid/guid_pool.go
+++ b/pkg/guid/guid_pool.go
@@ -3,6 +3,7 @@ package guid
 import (
 	"fmt"
 	"net"
+	"regexp"
 	"strings"
 
 	k8s_client "github.com/Mellanox/ib-kubernetes/pkg/k8s-client"
@@ -11,6 +12,7 @@ import (
 	"github.com/golang/glog"
 	netAttUtils "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/utils"
 	kapi "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 type GuidPool interface {
@@ -21,9 +23,9 @@ type GuidPool interface {
 	// AllocateGUID allocate given guid if in range or
 	// allocate the next free guid in the range if no given guid.
 	// It returns the allocated guid or error if range is full.
-	AllocateGUID(string, string) error
+	AllocateGUID(types.UID, string, string) error
 
-	GenerateGUID(string) (string, error)
+	GenerateGUID() (net.HardwareAddr, error)
 
 	// ReleaseGUID release the reservation of the guid.
 	// It returns error if the guid is not in the range.
@@ -49,12 +51,12 @@ func NewGuidPool(guidRangeStart, guidRangeEnd string, client k8s_client.Client) 
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse guidRangeStart %v", err)
 	}
-	if !isAllowedGUID(guidRangeStart) {
+	if !isValidGUID(guidRangeStart) {
 		err := fmt.Errorf("NewGuidPool(): invalid start guid range %s", guidRangeStart)
 		glog.Error(err)
 		return nil, err
 	}
-	if !isAllowedGUID(guidRangeEnd) {
+	if !isValidGUID(guidRangeEnd) {
 		err := fmt.Errorf("NewGuidPool(): invalid start guid range %s", guidRangeEnd)
 		glog.Error(err)
 		return nil, err
@@ -108,7 +110,7 @@ func (p *guidPool) InitPool() error {
 				continue
 			}
 
-			if err = p.AllocateGUID(string(pod.UID)+network.Name, guid); err != nil {
+			if err = p.AllocateGUID(pod.UID, network.Name, guid); err != nil {
 				err = fmt.Errorf("InitPool(): failed to allocate guid for running pod: %v", err)
 				glog.Error(err)
 				continue
@@ -120,8 +122,8 @@ func (p *guidPool) InitPool() error {
 }
 
 // GenerateGUID generates a guid from the range
-func (p *guidPool) GenerateGUID(podNetworkId string) (string, error) {
-	glog.Infof("GenerateGUID(): podNetworkId %s", podNetworkId)
+func (p *guidPool) GenerateGUID() (net.HardwareAddr, error) {
+	glog.Info("GenerateGUID():")
 
 	// this look will ensure that we check all the range
 	// first iteration from current guid to last guid in the range
@@ -140,12 +142,7 @@ func (p *guidPool) GenerateGUID(podNetworkId string) (string, error) {
 					p.currentGUID = p.getNextGUID(p.currentGUID)
 				}
 
-				guid := freeGUID.String()
-				if err := p.AllocateGUID(podNetworkId, guid); err != nil {
-					glog.Error(err)
-					return "", err
-				}
-				return guid, nil
+				return freeGUID, nil
 			}
 
 			if p.currentGUID.String() == p.rangeEnd.String() {
@@ -156,7 +153,7 @@ func (p *guidPool) GenerateGUID(podNetworkId string) (string, error) {
 
 		copy(p.currentGUID, p.rangeStart)
 	}
-	return "", fmt.Errorf("AllocateGUID(): the range is full")
+	return nil, fmt.Errorf("AllocateGUID(): the range is full")
 }
 
 // ReleaseGUID release allocated guid
@@ -173,13 +170,18 @@ func (p *guidPool) ReleaseGUID(guid string) error {
 }
 
 // AllocateGUID allocate guid for the pod
-func (p *guidPool) AllocateGUID(podNetworkId, guid string) error {
-	glog.Infof("AllocateGUID(): podNetworkId, %s guid %s", podNetworkId, guid)
+func (p *guidPool) AllocateGUID(podUid types.UID, networkName, guid string) error {
+	glog.Infof("AllocateGUID(): podUid %v, networkName %s, guid %s", podUid, networkName, guid)
 
 	if _, err := net.ParseMAC(guid); err != nil {
 		return err
 	}
 
+	if !isValidGUID(guid) {
+		return fmt.Errorf("AllocateGUID(): invalid guid %s", guid)
+	}
+
+	podNetworkId := string(podUid) + networkName
 	if _, exist := p.guidPoolMap[guid]; exist {
 		if podNetworkId != p.guidPodNetworkMap[guid] {
 			return fmt.Errorf("failed to allocate requested guid %s, already allocated for %s",
@@ -204,10 +206,6 @@ func (p *guidPool) getNextGUID(currentGUID net.HardwareAddr) net.HardwareAddr {
 	return currentGUID
 }
 
-func isAllowedGUID(guid string) bool {
-	return guid != "00:00:00:00:00:00:00:00" && !strings.EqualFold(guid, "ff:ff:ff:ff:ff:ff:ff:ff")
-}
-
 func checkGuidRange(startGUID, endGUID net.HardwareAddr) error {
 	glog.V(3).Infof("checkGuidRange(): startGUID %v, endGUID %s", startGUID.String(), endGUID.String())
 	for idx := 0; idx <= 7; idx++ {
@@ -220,4 +218,10 @@ func checkGuidRange(startGUID, endGUID net.HardwareAddr) error {
 	}
 
 	return nil
+}
+
+// isValidGUID check if the guild is valid
+func isValidGUID(guid string) bool {
+	match, _ := regexp.MatchString("^([0-9a-fA-F]{2}:){7}[0-9a-fA-F]{2}$", guid)
+	return match && guid != "00:00:00:00:00:00:00:00" && !strings.EqualFold(guid, "ff:ff:ff:ff:ff:ff:ff:ff")
 }

--- a/pkg/guid/guid_test.go
+++ b/pkg/guid/guid_test.go
@@ -114,79 +114,89 @@ var _ = Describe("GUID Pool", func() {
 		It("Generate guid when range is not full", func() {
 			pool, err := NewGuidPool("00:00:00:00:00:00:01:00", "00:00:00:00:00:00:01:01", nil)
 			Expect(err).ToNot(HaveOccurred())
-			guid, err := pool.GenerateGUID("")
+			guid, err := pool.GenerateGUID()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(guid).To(Equal("00:00:00:00:00:00:01:00"))
-			guid, err = pool.GenerateGUID("")
+			Expect(pool.AllocateGUID("", "", guid.String())).ToNot(HaveOccurred())
+			Expect(guid.String()).To(Equal("00:00:00:00:00:00:01:00"))
+			guid, err = pool.GenerateGUID()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(guid).To(Equal("00:00:00:00:00:00:01:01"))
+			Expect(guid.String()).To(Equal("00:00:00:00:00:00:01:01"))
 		})
 		It("Generate and release guid then re-allocate the newly released guids", func() {
 			pool, err := NewGuidPool("00:00:00:00:00:00:01:00", "00:00:00:00:00:00:01:ff",
 				nil)
 			Expect(err).ToNot(HaveOccurred())
-			guid, err := pool.GenerateGUID("")
+			guid, err := pool.GenerateGUID()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(guid).To(Equal("00:00:00:00:00:00:01:00"))
-			err = pool.ReleaseGUID(guid)
+			Expect(guid.String()).To(Equal("00:00:00:00:00:00:01:00"))
+			Expect(pool.AllocateGUID("", "", guid.String())).ToNot(HaveOccurred())
+			err = pool.ReleaseGUID(guid.String())
 			Expect(err).ToNot(HaveOccurred())
 
 			// Generate all the range
 			Expect(err).ToNot(HaveOccurred())
 			for i := 0; i < 255; i++ {
-				_, err = pool.GenerateGUID("pod" + string(i))
+				guid, err = pool.GenerateGUID()
 				Expect(err).ToNot(HaveOccurred())
+				Expect(pool.AllocateGUID("", "", guid.String())).ToNot(HaveOccurred())
 			}
 
 			// After the last guid in the pool was allocated then the pool check back from first guid
-			guid, err = pool.GenerateGUID("")
+			guid, err = pool.GenerateGUID()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(guid).To(Equal("00:00:00:00:00:00:01:00"))
+			Expect(guid.String()).To(Equal("00:00:00:00:00:00:01:00"))
 		})
 		It("Generate guid when current guid is allocated", func() {
 			p, err := NewGuidPool("00:00:00:00:00:00:01:00", "00:00:00:00:00:00:01:01", nil)
 			Expect(err).ToNot(HaveOccurred())
-			err = p.AllocateGUID("", "00:00:00:00:00:00:01:00")
+			err = p.AllocateGUID("", "", "00:00:00:00:00:00:01:00")
+			Expect(err).ToNot(HaveOccurred())
 			Expect(err).ToNot(HaveOccurred())
 
-			guid, err := p.GenerateGUID("")
+			guid, err := p.GenerateGUID()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(guid).To(Equal("00:00:00:00:00:00:01:01"))
+			Expect(guid.String()).To(Equal("00:00:00:00:00:00:01:01"))
 		})
 		It("Generate guid when range is full", func() {
 			pool, err := NewGuidPool("00:00:00:00:00:00:01:00", "00:00:00:00:00:00:01:00", nil)
 			Expect(err).ToNot(HaveOccurred())
-			guid, err := pool.GenerateGUID("")
+			guid, err := pool.GenerateGUID()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(guid).To(Equal("00:00:00:00:00:00:01:00"))
-			guid, err = pool.GenerateGUID("")
+			Expect(guid.String()).To(Equal("00:00:00:00:00:00:01:00"))
+			Expect(pool.AllocateGUID("pod1", "test", guid.String())).ToNot(HaveOccurred())
+			guid, err = pool.GenerateGUID()
 			Expect(err).To(HaveOccurred())
-			Expect(guid).To(Equal(""))
+			Expect(guid).To(BeNil())
 		})
 	})
 	Context("AllocateGUID", func() {
 		It("Allocate guid from the pool", func() {
 			pool := &guidPool{guidPoolMap: map[string]bool{}, guidPodNetworkMap: map[string]string{}}
-			err := pool.AllocateGUID("", "02:00:00:00:00:00:00:00")
+			err := pool.AllocateGUID("", "", "02:00:00:00:00:00:00:00")
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("Allocate an allocated guid from the pool for the same pod", func() {
 			pool := &guidPool{guidPoolMap: map[string]bool{}, guidPodNetworkMap: map[string]string{}}
-			err := pool.AllocateGUID("pod1", "02:00:00:00:00:00:00:00")
+			err := pool.AllocateGUID("pod1", "test", "02:00:00:00:00:00:00:00")
 			Expect(err).ToNot(HaveOccurred())
-			err = pool.AllocateGUID("pod1", "02:00:00:00:00:00:00:00")
+			err = pool.AllocateGUID("pod1", "test", "02:00:00:00:00:00:00:00")
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("Allocate an allocated guid from the pool", func() {
 			pool := &guidPool{guidPoolMap: map[string]bool{}, guidPodNetworkMap: map[string]string{}}
-			err := pool.AllocateGUID("pod1", "02:00:00:00:00:00:00:00")
+			err := pool.AllocateGUID("pod1", "test", "02:00:00:00:00:00:00:00")
 			Expect(err).ToNot(HaveOccurred())
-			err = pool.AllocateGUID("pod2", "02:00:00:00:00:00:00:00")
+			err = pool.AllocateGUID("pod2", "test", "02:00:00:00:00:00:00:00")
 			Expect(err).To(HaveOccurred())
 		})
 		It("Allocate invalid guid from the pool", func() {
 			pool := &guidPool{guidPoolMap: map[string]bool{}}
-			err := pool.AllocateGUID("", "invalid")
+			err := pool.AllocateGUID("", "", "invalid")
+			Expect(err).To(HaveOccurred())
+		})
+		It("Allocate valid network address but invalid guid from the pool", func() {
+			pool := &guidPool{guidPoolMap: map[string]bool{}}
+			err := pool.AllocateGUID("", "", "00:00:00:00:00:00:00:00")
 			Expect(err).To(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
When pod failed in perodic update in cases like setting annotations
for the pod or ufm is not unavailable, the daemon allocates new guids
for that pod if it doesn't have guid predefined in the cni-args.