### PR TITLE
Fix: Remove non InfiniBand SR-IOV CNI networks from periodic add

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -131,6 +131,7 @@ func (d *daemon) AddPeriodicUpdate() {
 
 		ibCniSpec, err := utils.IsIbSriovCniInNetwork(networkSpec)
 		if err != nil {
+			addMap.UnSafeRemove(networkName)
 			glog.Warningf("AddPeriodicUpdate(): %v", err)
 			// skip failed network
 			continue


### PR DESCRIPTION
This commit removes networks that are neither of type ib-sriov-cni nor use chain plugin that includes ib-sriov-cni, which are processed and fail every time the periodic add is called
