### PR TITLE
Partition Environment variables into groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,18 +67,18 @@ $ DOCKERFILE=myfile TAG=mytag make image
 ## Configuration Reference
 
 User can provide the following configurations as environment variables or for the ConfigMap :
-* PLUGIN: Name of the subnet manager plugin, currently supported "noop" and "ufm".
-* PERIODIC_UPDATE: Interval in seconds to send add and remove request to subnet manager.
-* RANGE_START: The first guid in the pool to generated, e.g: "02:00:00:00:00:00:00:00".
-* RANGE_END: The Last guid in the pool.
+* `DAEMON_SM_PLUGIN`: Name of the subnet manager plugin. Currently supported `"noop"` and `"ufm"`.
+* `DAEMON_PERIODIC_UPDATE`: Interval in seconds to send add and remove request to subnet manager.
+* `GUID_POOL_RANGE_START`: The first guid in the pool e.g: `"02:00:00:00:00:00:00:00"`.
+* `GUID_POOL_RANGE_END`: The Last guid in the pool.
 
 **Configurations if "ufm" subnet manager plugin is used for  `deployment/ib-kubernetes-ufm-secret.yaml`:**
-* UFM_USERNAME: Username of UFM. 
-* UFM_PASSWORD: Password of UFM.
-* UFM_ADDRESS: IP address or hostname of UFM server.
-* UFM_HTTP_SCHEMA: http/https, default is https.
-* UFM_PORT: REST API port of UFM default is 443, if `httpSchema` is http then default is 80.
-* UFM_CERTIFICATE: Secure certificate if using secure connection.
+* `UFM_USERNAME`: Username of UFM.
+* `UFM_PASSWORD`: Password of UFM.
+* `UFM_ADDRESS`: IP address or hostname of UFM server.
+* `UFM_HTTP_SCHEMA`: http/https, default is https.
+* `UFM_PORT`: REST API port of UFM default is 443 (https), if `httpSchema` is set to http then the default is 80.
+* `UFM_CERTIFICATE`: Secure certificate if using secure connection.
 
 ## Deployment
 

--- a/deployment/ib-kubernetes-configmap.yaml
+++ b/deployment/ib-kubernetes-configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ib-kubernetes-config
   namespace: kube-system
 data:
-  SM_PLUGIN: "ufm"
-  PERIODIC_UPDATE: "5"
-  RANGE_START: "02:00:00:00:00:00:00:00"
-  RANGE_END: "02:FF:FF:FF:FF:FF:FF:FF"
+  DAEMON_SM_PLUGIN: "ufm"
+  DAEMON_PERIODIC_UPDATE: "5"
+  GUID_POOL_RANGE_START: "02:00:00:00:00:00:00:00"
+  GUID_POOL_RANGE_END: "02:FF:FF:FF:FF:FF:FF:FF"

--- a/deployment/ib-kubernetes-ds.yaml
+++ b/deployment/ib-kubernetes-ds.yaml
@@ -63,26 +63,26 @@ spec:
             - "-logtostderr"
             - "-v=3"
           env:
-            - name: PLUGIN
+            - name: DAEMON_SM_PLUGIN
               valueFrom:
                 configMapKeyRef:
                   name: ib-kubernetes-config
-                  key: PLUGIN
-            - name: PERIODIC_UPDATE
+                  key: DAEMON_SM_PLUGIN
+            - name: DAEMON_PERIODIC_UPDATE
               valueFrom:
                 configMapKeyRef:
                   name: ib-kubernetes-config
-                  key: PERIODIC_UPDATE
-            - name: RANGE_START
+                  key: DAEMON_PERIODIC_UPDATE
+            - name: GUID_POOL_RANGE_START
               valueFrom:
                 configMapKeyRef:
                   name: ib-kubernetes-config
-                  key: RANGE_START
-            - name: RANGE_END
+                  key: GUID_POOL_RANGE_START
+            - name: GUID_POOL_RANGE_END
               valueFrom:
                 configMapKeyRef:
                   name: ib-kubernetes-config
-                  key: RANGE_END
+                  key: GUID_POOL_RANGE_END
             - name: UFM_USERNAME
               valueFrom:
                 secretKeyRef:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,14 +8,14 @@ import (
 )
 
 type DaemonConfig struct {
-	PeriodicUpdate int `env:"PERIODIC_UPDATE" envDefault:"5"` // Interval between every check for the added and deleted pods
+	PeriodicUpdate int `env:"DAEMON_PERIODIC_UPDATE" envDefault:"5"` // Interval between every check for the added and deleted pods
 	GuidPool       GuidPoolConfig
-	Plugin         string `env:"SM_PLUGIN"` // Subnet manager plugin name
+	Plugin         string `env:"DAEMON_SM_PLUGIN"` // Subnet manager plugin name
 }
 
 type GuidPoolConfig struct {
-	RangeStart string `env:"RANGE_START" envDefault:"02:00:00:00:00:00:00:00"` // First guid in the pool
-	RangeEnd   string `env:"RANGE_END"   envDefault:"02:FF:FF:FF:FF:FF:FF:FF"` // Last guid in the pool
+	RangeStart string `env:"GUID_POOL_RANGE_START" envDefault:"02:00:00:00:00:00:00:00"` // First guid in the pool
+	RangeEnd   string `env:"GUID_POOL_RANGE_END"   envDefault:"02:FF:FF:FF:FF:FF:FF:FF"` // Last guid in the pool
 }
 
 func (dc *DaemonConfig) ReadConfig() error {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -15,10 +15,10 @@ var _ = Describe("Configuration", func() {
 		It("Read configuration from environment variables", func() {
 			dc := &DaemonConfig{}
 
-			Expect(os.Setenv("PERIODIC_UPDATE", "10")).ToNot(HaveOccurred())
-			Expect(os.Setenv("RANGE_START", "02:00:00:00:00:00:00:00")).ToNot(HaveOccurred())
-			Expect(os.Setenv("RANGE_END", "02:00:00:00:00:00:00:FF")).ToNot(HaveOccurred())
-			Expect(os.Setenv("SM_PLUGIN", "ufm")).ToNot(HaveOccurred())
+			Expect(os.Setenv("DAEMON_PERIODIC_UPDATE", "10")).ToNot(HaveOccurred())
+			Expect(os.Setenv("GUID_POOL_RANGE_START", "02:00:00:00:00:00:00:00")).ToNot(HaveOccurred())
+			Expect(os.Setenv("GUID_POOL_RANGE_END", "02:00:00:00:00:00:00:FF")).ToNot(HaveOccurred())
+			Expect(os.Setenv("DAEMON_SM_PLUGIN", "ufm")).ToNot(HaveOccurred())
 
 			err := dc.ReadConfig()
 			Expect(err).ToNot(HaveOccurred())
@@ -29,7 +29,7 @@ var _ = Describe("Configuration", func() {
 		})
 		It("Read configuration with default values", func() {
 			dc := &DaemonConfig{}
-			Expect(os.Setenv("SM_PLUGIN", "ufm")).ToNot(HaveOccurred())
+			Expect(os.Setenv("DAEMON_SM_PLUGIN", "ufm")).ToNot(HaveOccurred())
 
 			err := dc.ReadConfig()
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
This commit partitions the defined environment variables into logical
group to provide a more consistent and extendable user facing API

The groups are defnied by the component they are in:
- DAEMON_*  : ib-kubernetes daemon related configurations via
              environment variables
- GUID_POOL_* : guid pool related configurations via environment
                variables
- UFM_* : UFM plugin related configurations visa environment variables
          (was already present)

Documents and deployment files updated accordingly