### PR TITLE
Utils nits

### DIFF
--- a/pkg/ib-utils/utils.go
+++ b/pkg/ib-utils/utils.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 )
 
-// IsPKeyValid check if the pkey is in the valid range
+// IsPKeyValid check if the pkey is in the valid (15bits long)
 func IsPKeyValid(pkey int) bool {
-	return pkey > 0x0000 && pkey < 0xFFFF
+	return pkey == (pkey & 0x7fff)
 }
 
 // GuidToString return string guid from HardwareAddr

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -68,7 +68,7 @@ func GetPodNetworkGuid(network *v1.NetworkSelectionElement) (string, error) {
 		return "", fmt.Errorf("no \"guid\" field in network %v", network)
 	}
 
-	return fmt.Sprintf("%v", guid), nil
+	return fmt.Sprintf("%s", guid), nil
 }
 
 // SetPodNetworkGuid set network cni-args guid
@@ -95,7 +95,7 @@ func IsIbSriovCniInNetwork(networkSpec map[string]interface{}) (*IbSriovCniSpec,
 		ibSpec := &IbSriovCniSpec{Type: InfiniBandSriovCni}
 		pkey, ok := networkSpec["pkey"]
 		if ok {
-			ibSpec.PKey = fmt.Sprintf("%v", pkey)
+			ibSpec.PKey = fmt.Sprintf("%s", pkey)
 		}
 
 		return ibSpec, nil


### PR DESCRIPTION
- Optimize check for valid pkey
- Explicitly use %s in Sprintf when extracting guid/pkey from
  CNI args/net-attach-def