### PR TITLE
Moved the k8s logic inside guid_pool.go to the daemon.go

### DIFF
--- a/pkg/guid/guid_pool.go
+++ b/pkg/guid/guid_pool.go
@@ -4,24 +4,15 @@ import (
 	"fmt"
 
 	"github.com/Mellanox/ib-kubernetes/pkg/config"
-	k8s_client "github.com/Mellanox/ib-kubernetes/pkg/k8s-client"
-	"github.com/Mellanox/ib-kubernetes/pkg/utils"
 
-	netAttUtils "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/utils"
 	"github.com/rs/zerolog/log"
-	kapi "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 type GuidPool interface {
-	// InitPool initializes the pool and marks the allocated guids from previous session.
-	// It returns error in case of failure.
-	InitPool() error
-
 	// AllocateGUID allocate given guid if in range or
 	// allocate the next free guid in the range if no given guid.
 	// It returns the allocated guid or error if range is full.
-	AllocateGUID(types.UID, string, string) error
+	AllocateGUID(string) error
 
 	GenerateGUID() (GUID, error)
 
@@ -31,15 +22,13 @@ type GuidPool interface {
 }
 
 type guidPool struct {
-	kubeClient        k8s_client.Client // kubernetes client
-	rangeStart        GUID              // first guid in range
-	rangeEnd          GUID              // last guid in range
-	currentGUID       GUID              // last given guid
-	guidPoolMap       map[GUID]bool     // allocated guid map and status
-	guidPodNetworkMap map[string]string // allocated guid mapped to the pod and network
+	rangeStart  GUID          // first guid in range
+	rangeEnd    GUID          // last guid in range
+	currentGUID GUID          // last given guid
+	guidPoolMap map[GUID]bool // allocated guid map and status
 }
 
-func NewGuidPool(conf *config.GuidPoolConfig, client k8s_client.Client) (GuidPool, error) {
+func NewGuidPool(conf *config.GuidPoolConfig) (GuidPool, error) {
 	log.Info().Msgf("creating guid pool, guidRangeStart %s, guidRangeEnd %s", conf.RangeStart, conf.RangeEnd)
 	rangeStart, err := ParseGUID(conf.RangeStart)
 	if err != nil {
@@ -54,49 +43,11 @@ func NewGuidPool(conf *config.GuidPoolConfig, client k8s_client.Client) (GuidPoo
 	}
 
 	return &guidPool{
-		rangeStart:        rangeStart,
-		rangeEnd:          rangeEnd,
-		currentGUID:       rangeStart,
-		guidPoolMap:       map[GUID]bool{},
-		guidPodNetworkMap: map[string]string{},
-		kubeClient:        client}, nil
-}
-
-//  InitPool check the guids that are already allocated by the running pods
-func (p *guidPool) InitPool() error {
-	log.Info().Msg("Initializing Pool")
-	pods, err := p.kubeClient.GetPods(kapi.NamespaceAll)
-	if err != nil {
-		return fmt.Errorf("failed to get pods from kubernetes: %v", err)
-	}
-
-	for index := range pods.Items {
-		log.Debug().Msgf("checking pod for network annotations %v", pods.Items[index])
-		pod := pods.Items[index]
-		networks, err := netAttUtils.ParsePodNetworkAnnotation(&pod)
-		if err != nil {
-			continue
-		}
-
-		for _, network := range networks {
-			if !utils.IsPodNetworkConfiguredWithInfiniBand(network) {
-				continue
-			}
-
-			guid, err := utils.GetPodNetworkGuid(network)
-			if err != nil {
-				continue
-			}
-
-			if err = p.AllocateGUID(pod.UID, network.Name, guid); err != nil {
-				log.Warn().Msgf("failed to allocate guid for running pod %s, namespace %s: %v",
-					pod.Name, pod.Namespace, err)
-				continue
-			}
-		}
-	}
-
-	return nil
+		rangeStart:  rangeStart,
+		rangeEnd:    rangeEnd,
+		currentGUID: rangeStart,
+		guidPoolMap: map[GUID]bool{},
+	}, nil
 }
 
 // GenerateGUID generates a guid from the range
@@ -126,13 +77,12 @@ func (p *guidPool) ReleaseGUID(guid string) error {
 		return fmt.Errorf("failed to release guid %s, not allocated ", guid)
 	}
 	delete(p.guidPoolMap, guidAddr)
-	delete(p.guidPodNetworkMap, guid)
 	return nil
 }
 
 // AllocateGUID allocate guid for the pod
-func (p *guidPool) AllocateGUID(podUid types.UID, networkId, guid string) error {
-	log.Debug().Msgf("allocating guid %s, for podUid %v, networkId %s", guid, podUid, networkId)
+func (p *guidPool) AllocateGUID(guid string) error {
+	log.Debug().Msgf("allocating guid %s", guid)
 
 	guidAddr, err := ParseGUID(guid)
 	if err != nil {
@@ -143,17 +93,11 @@ func (p *guidPool) AllocateGUID(podUid types.UID, networkId, guid string) error 
 		return fmt.Errorf("out of range guid %s, pool range %v - %v", guid, p.rangeStart, p.rangeEnd)
 	}
 
-	podNetworkId := string(podUid) + networkId
 	if _, exist := p.guidPoolMap[guidAddr]; exist {
-		if podNetworkId != p.guidPodNetworkMap[guid] {
-			return fmt.Errorf("failed to allocate requested guid %s, already allocated for %s",
-				guid, p.guidPodNetworkMap[guid])
-		}
-		return nil
+		return fmt.Errorf("failed to allocate requested guid %s, already allocated.", guid)
 	}
 
 	p.guidPoolMap[guidAddr] = true
-	p.guidPodNetworkMap[guid] = podNetworkId
 	return nil
 }
 

--- a/pkg/guid/guid_test.go
+++ b/pkg/guid/guid_test.go
@@ -1,111 +1,60 @@
 package guid
 
 import (
-	"errors"
-
 	"github.com/Mellanox/ib-kubernetes/pkg/config"
-	"github.com/Mellanox/ib-kubernetes/pkg/k8s-client/mocks"
 
-	v1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	kapi "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("GUID Pool", func() {
 	conf := &config.GuidPoolConfig{RangeStart: "02:00:00:00:00:00:00:00", RangeEnd: "02:FF:FF:FF:FF:FF:FF:FF"}
 	Context("NewGuidPool", func() {
 		It("Create guid pool with valid  parameters", func() {
-			pool, err := NewGuidPool(conf, nil)
+			pool, err := NewGuidPool(conf)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pool).ToNot(BeNil())
 		})
 		It("Create guid pool with invalid start guid", func() {
 			invalidConf := &config.GuidPoolConfig{RangeStart: "invalid", RangeEnd: "02:FF:FF:FF:FF:FF:FF:FF"}
-			pool, err := NewGuidPool(invalidConf, nil)
+			pool, err := NewGuidPool(invalidConf)
 			Expect(err).To(HaveOccurred())
 			Expect(pool).To(BeNil())
 		})
 		It("Create guid pool with invalid end guid", func() {
 			invalidConf := &config.GuidPoolConfig{RangeStart: "02:00:00:00:00:00:00:00", RangeEnd: "invalid"}
-			pool, err := NewGuidPool(invalidConf, nil)
+			pool, err := NewGuidPool(invalidConf)
 			Expect(err).To(HaveOccurred())
 			Expect(pool).To(BeNil())
 		})
 		It("Create guid pool with not allowed start guid", func() {
 			invalidRangeStartConf := &config.GuidPoolConfig{RangeStart: "00:00:00:00:00:00:00:00", RangeEnd: "02:FF:FF:FF:FF:FF:FF:FF"}
-			pool, err := NewGuidPool(invalidRangeStartConf, nil)
+			pool, err := NewGuidPool(invalidRangeStartConf)
 			Expect(err).To(HaveOccurred())
 			Expect(pool).To(BeNil())
 		})
 		It("Create guid pool with not allowed end guid", func() {
 			invalidRangeEndConf := &config.GuidPoolConfig{RangeStart: "02:00:00:00:00:00:00:00", RangeEnd: "FF:FF:FF:FF:FF:FF:FF:FF"}
-			pool, err := NewGuidPool(invalidRangeEndConf, nil)
+			pool, err := NewGuidPool(invalidRangeEndConf)
 			Expect(err).To(HaveOccurred())
 			Expect(pool).To(BeNil())
 		})
 		It("Create guid pool with invalid range", func() {
 			invalidRangeConf := &config.GuidPoolConfig{RangeStart: "02:FF:FF:FF:FF:FF:FF:FF", RangeEnd: "02:00:00:00:00:00:00:00"}
-			pool, err := NewGuidPool(invalidRangeConf, nil)
+			pool, err := NewGuidPool(invalidRangeConf)
 			Expect(err).To(HaveOccurred())
 			Expect(pool).To(BeNil())
 		})
 
 	})
-	Context("InitPool", func() {
-		It("Init pool with pods running pods allocated guid", func() {
-			client := &mocks.Client{}
-			pods := &kapi.PodList{Items: []kapi.Pod{}}
-			pod1 := kapi.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "default", Annotations: map[string]string{
-				v1.NetworkAttachmentAnnot: `[{"name":"test3","cni-args":{"guid":"02:00:00:00:00:00:00:03", "mellanox.infiniband.app":"configured"}}]`}}}
-			pod2 := kapi.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p2", Namespace: "default", Annotations: map[string]string{
-				v1.NetworkAttachmentAnnot: `[{"name":"test","cni-args":{"guid":"02:00:00:00:00:00:00:04", "mellanox.infiniband.app":"configured"}},
-                {"name":"test2","cni-args":{"guid":"02:00:00:00:00:00:00:05", "mellanox.infiniband.app":"configured"}}]`}}}
-			pod3 := kapi.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p3", Namespace: "default", Annotations: map[string]string{
-				v1.NetworkAttachmentAnnot: `[{"name":"test","cni-args":{"guid":"02:00:00:00:00:00:00:03", "mellanox.infiniband.app":"configured"}}]`}}}
-			pod4 := kapi.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p4", Namespace: "foo", Annotations: map[string]string{
-				v1.NetworkAttachmentAnnot: `[{"name":"test","namespace":"foo", "cni-args":{"mellanox.infiniband.app":"configured"}}]`}}}
-			pod5 := kapi.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p5", Namespace: "foo", Annotations: map[string]string{
-				v1.NetworkAttachmentAnnot: `[{"name":"test","namespace":"foo"}]`}}}
-			pod6 := kapi.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p6", Namespace: "foo"}}
-
-			pods.Items = append(pods.Items, pod1)
-			pods.Items = append(pods.Items, pod2)
-			pods.Items = append(pods.Items, pod3)
-			pods.Items = append(pods.Items, pod4)
-			pods.Items = append(pods.Items, pod5)
-			pods.Items = append(pods.Items, pod6)
-
-			client.On("GetPods", "").Return(pods, nil)
-			pool, err := NewGuidPool(conf, client)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(pool).ToNot(BeNil())
-
-			err = pool.InitPool()
-			Expect(err).ToNot(HaveOccurred())
-		})
-		It("Init pool failed to get pods", func() {
-			client := &mocks.Client{}
-
-			client.On("GetPods", "").Return(nil, errors.New("err"))
-			pool, err := NewGuidPool(conf, client)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(pool).ToNot(BeNil())
-
-			err = pool.InitPool()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("failed to get pods from kubernetes: err"))
-		})
-	})
 	Context("GenerateGUID", func() {
 		It("Generate guid when range is not full", func() {
 			poolConfig := &config.GuidPoolConfig{RangeStart: "00:00:00:00:00:00:01:00", RangeEnd: "00:00:00:00:00:00:01:01"}
-			pool, err := NewGuidPool(poolConfig, nil)
+			pool, err := NewGuidPool(poolConfig)
 			Expect(err).ToNot(HaveOccurred())
 			guid, err := pool.GenerateGUID()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(pool.AllocateGUID("", "", guid.String())).ToNot(HaveOccurred())
+			Expect(pool.AllocateGUID(guid.String())).ToNot(HaveOccurred())
 			Expect(guid.String()).To(Equal("00:00:00:00:00:00:01:00"))
 			guid, err = pool.GenerateGUID()
 			Expect(err).ToNot(HaveOccurred())
@@ -113,12 +62,12 @@ var _ = Describe("GUID Pool", func() {
 		})
 		It("Generate and release guid then re-allocate the newly released guids", func() {
 			poolConfig := &config.GuidPoolConfig{RangeStart: "00:00:00:00:00:00:01:00", RangeEnd: "00:00:00:00:00:00:01:ff"}
-			pool, err := NewGuidPool(poolConfig, nil)
+			pool, err := NewGuidPool(poolConfig)
 			Expect(err).ToNot(HaveOccurred())
 			guid, err := pool.GenerateGUID()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(guid.String()).To(Equal("00:00:00:00:00:00:01:00"))
-			Expect(pool.AllocateGUID("", "", guid.String())).ToNot(HaveOccurred())
+			Expect(pool.AllocateGUID(guid.String())).ToNot(HaveOccurred())
 			err = pool.ReleaseGUID(guid.String())
 			Expect(err).ToNot(HaveOccurred())
 
@@ -127,7 +76,7 @@ var _ = Describe("GUID Pool", func() {
 			for i := 0; i < 255; i++ {
 				guid, err = pool.GenerateGUID()
 				Expect(err).ToNot(HaveOccurred())
-				Expect(pool.AllocateGUID("", "", guid.String())).ToNot(HaveOccurred())
+				Expect(pool.AllocateGUID(guid.String())).ToNot(HaveOccurred())
 			}
 
 			// After the last guid in the pool was allocated then the pool check back from first guid
@@ -137,9 +86,9 @@ var _ = Describe("GUID Pool", func() {
 		})
 		It("Generate guid when current guid is allocated", func() {
 			poolConfig := &config.GuidPoolConfig{RangeStart: "00:00:00:00:00:00:01:00", RangeEnd: "00:00:00:00:00:00:01:01"}
-			p, err := NewGuidPool(poolConfig, nil)
+			p, err := NewGuidPool(poolConfig)
 			Expect(err).ToNot(HaveOccurred())
-			err = p.AllocateGUID("", "", "00:00:00:00:00:00:01:00")
+			err = p.AllocateGUID("00:00:00:00:00:00:01:00")
 			Expect(err).ToNot(HaveOccurred())
 
 			guid, err := p.GenerateGUID()
@@ -148,54 +97,46 @@ var _ = Describe("GUID Pool", func() {
 		})
 		It("Generate guid when range is full", func() {
 			poolConfig := &config.GuidPoolConfig{RangeStart: "00:00:00:00:00:00:01:00", RangeEnd: "00:00:00:00:00:00:01:00"}
-			pool, err := NewGuidPool(poolConfig, nil)
+			pool, err := NewGuidPool(poolConfig)
 			Expect(err).ToNot(HaveOccurred())
 			guid, err := pool.GenerateGUID()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(guid.String()).To(Equal("00:00:00:00:00:00:01:00"))
-			Expect(pool.AllocateGUID("pod1", "test", guid.String())).ToNot(HaveOccurred())
+			Expect(pool.AllocateGUID(guid.String())).ToNot(HaveOccurred())
 			_, err = pool.GenerateGUID()
 			Expect(err).To(HaveOccurred())
 		})
 	})
 	Context("AllocateGUID", func() {
 		It("Allocate guid from the pool", func() {
-			pool, err := NewGuidPool(conf, nil)
+			pool, err := NewGuidPool(conf)
 			Expect(err).ToNot(HaveOccurred())
-			err = pool.AllocateGUID("", "", "02:00:00:00:00:00:00:00")
+			err = pool.AllocateGUID("02:00:00:00:00:00:00:00")
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("Allocate out of range guid from the pool", func() {
-			pool, err := NewGuidPool(conf, nil)
+			pool, err := NewGuidPool(conf)
 			Expect(err).ToNot(HaveOccurred())
-			err = pool.AllocateGUID("pod1", "test", "55:00:00:00:00:00:00:FF")
+			err = pool.AllocateGUID("55:00:00:00:00:00:00:FF")
 			Expect(err).To(HaveOccurred())
 		})
-		It("Allocate an allocated guid from the pool for the same pod", func() {
-			pool, err := NewGuidPool(conf, nil)
-			Expect(err).ToNot(HaveOccurred())
-			err = pool.AllocateGUID("pod1", "test", "02:00:00:00:00:00:00:00")
-			Expect(err).ToNot(HaveOccurred())
-			err = pool.AllocateGUID("pod1", "test", "02:00:00:00:00:00:00:00")
-			Expect(err).ToNot(HaveOccurred())
-		})
 		It("Allocate an allocated guid from the pool", func() {
-			pool, err := NewGuidPool(conf, nil)
+			pool, err := NewGuidPool(conf)
 			Expect(err).ToNot(HaveOccurred())
-			err = pool.AllocateGUID("pod1", "test", "02:00:00:00:00:00:00:00")
+			err = pool.AllocateGUID("02:00:00:00:00:00:00:00")
 			Expect(err).ToNot(HaveOccurred())
-			err = pool.AllocateGUID("pod2", "test", "02:00:00:00:00:00:00:00")
+			err = pool.AllocateGUID("02:00:00:00:00:00:00:00")
 			Expect(err).To(HaveOccurred())
 		})
 		It("Allocate invalid guid from the pool", func() {
 			pool := &guidPool{guidPoolMap: map[GUID]bool{}}
-			err := pool.AllocateGUID("", "", "invalid")
+			err := pool.AllocateGUID("invalid")
 			Expect(err).To(HaveOccurred())
 		})
 		It("Allocate valid network address but invalid guid from the pool", func() {
-			pool, err := NewGuidPool(conf, nil)
+			pool, err := NewGuidPool(conf)
 			Expect(err).ToNot(HaveOccurred())
-			err = pool.AllocateGUID("", "", "00:00:00:00:00:00:00:00")
+			err = pool.AllocateGUID("00:00:00:00:00:00:00:00")
 			Expect(err).To(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
Moved the InitPool() function which read the existing pods guids
and store them from the guid_pool.go to the main.go. Also moved
the guidPodNetworkMap which contains a map between the pods and
their guids from the guid_pool.go to daemon.go and made the necessary
changes.

fixes #44