### PR TITLE
Fix ufm secret file

### DIFF
--- a/deployment/ib-kubernetes-ufm-secret.yaml
+++ b/deployment/ib-kubernetes-ufm-secret.yaml
@@ -9,5 +9,5 @@ stringData:
   UFM_ADDRESS: ""
   UFM_HTTP_SCHEMA: ""
   UFM_PORT: ""
-string:
+data:
   UFM_CERTIFICATE: ""


### PR DESCRIPTION
[root@r-cloudx2-01 ib-kubernetes]# kubectl create -f deployment/ib-kubernetes-ufm-secret.yaml 
error: error validating "deployment/ib-kubernetes-ufm-secret.yaml": error validating data: ValidationError(Secret): unknown field "string" in io.k8s.api.core.v1.Secret; if you choose to ignore these errors, turn validation off with --validate=false