### PR TITLE
Add clean modcache to Makefile clean step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,7 @@ image: ; $(info Building Docker image...)  ## Build conatiner image
 
 .PHONY: clean
 clean: ; $(info  Cleaning...)	 ## Cleanup everything
+	@$(GO) clean -modcache
 	@rm -rf $(GOPATH)
 	@rm -rf $(BUILDDIR)
 	@rm -rf  test


### PR DESCRIPTION
As go mod creates files as read only, the usual
`rm -rf` wont work.

We should do it the go mod way.