### PR TITLE
Change the ib-sriov-cni name to ib-sriov

### DIFF
--- a/deployment/examples/ib-crd.yaml
+++ b/deployment/examples/ib-crd.yaml
@@ -6,7 +6,7 @@ metadata:
     k8s.v1.cni.cncf.io/resourceName: mellanox.com/mlnx_sriov_rdma_ib
 spec:
   config: '{
-  "type": "ib-sriov-cni",
+  "type": "ib-sriov",
   "cniVersion": "0.3.1",
   "name": "sriov-network",
   "pkey": "0x5",

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -19,7 +19,7 @@ type IbSriovCniSpec struct {
 const (
 	InfiniBandAnnotation    = "mellanox.infiniband.app"
 	ConfiguredInfiniBandPod = "configured"
-	InfiniBandSriovCni      = "ib-sriov-cni"
+	InfiniBandSriovCni      = "ib-sriov"
 )
 
 // PodWantsNetwork check if pod needs cni
@@ -106,7 +106,7 @@ func GetIbSriovCniFromNetwork(networkSpec map[string]interface{}) (*IbSriovCniSp
 	if !ok {
 		return nil, fmt.Errorf(
 			"network spec type \"%s\" is not supported and \"plugins\" field not found, "+
-				"supported type \"ib-sriov-cni\"",
+				"supported type \"ib-sriov\"",
 			networkSpec["type"])
 	}
 
@@ -126,7 +126,7 @@ func GetIbSriovCniFromNetwork(networkSpec map[string]interface{}) (*IbSriovCniSp
 		}
 	}
 
-	return nil, fmt.Errorf("cni plugin ib-sriov-cni not found")
+	return nil, fmt.Errorf("cni plugin ib-sriov not found")
 }
 
 func GetPodNetwork(networks []*v1.NetworkSelectionElement, networkName string) (*v1.NetworkSelectionElement, error) {


### PR DESCRIPTION
Following the recent rename of the ib-sriov-cni bin name to
ib-sriov, this patch changes its name in the appropriate places
in the ib-kubernetes project.