### PR TITLE
Add version flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ADD . /usr/src/ib-kubernetes
 ENV HTTP_PROXY $http_proxy
 ENV HTTPS_PROXY $https_proxy
 
-RUN apk add --update --virtual build-dependencies build-base linux-headers && \
+RUN apk add --update --virtual build-dependencies build-base linux-headers git && \
     cd /usr/src/ib-kubernetes && \
     make clean && \
     make

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,12 @@ export GOPATH
 export GOBIN
 export CGO_ENABLED=1
 
+# Version
+VERSION?=master
+DATE=`date -Iseconds`
+COMMIT?=`git rev-parse --verify HEAD`
+LDFLAGS="-X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)"
+
 # Docker
 IMAGE_BUILDER?=@docker
 DOCKERFILE?=$(CURDIR)/Dockerfile
@@ -53,7 +59,7 @@ build: $(BUILDDIR)/$(BINARY_NAME) ; $(info Building $(BINARY_NAME)...) ## Build 
 	$(info Done!)
 
 $(BUILDDIR)/$(BINARY_NAME): $(GOFILES) | $(BUILDDIR)
-	@cd cmd/$(BINARY_NAME) && $(GO) build -o $(BUILDDIR)/$(BINARY_NAME) -tags no_openssl -v
+	@cd cmd/$(BINARY_NAME) && $(GO) build -o $(BUILDDIR)/$(BINARY_NAME) -tags no_openssl -ldflags $(LDFLAGS) -v
 
 # Tools
 

--- a/cmd/ib-kubernetes/main.go
+++ b/cmd/ib-kubernetes/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 
 	"github.com/rs/zerolog"
@@ -11,6 +12,12 @@ import (
 )
 
 const exitError = 1
+
+var (
+	version = "master@git"
+	commit  = "unknown commit"
+	date    = "unknown date"
+)
 
 func setupLogging(debug bool) {
 	if debug {
@@ -24,10 +31,25 @@ func setupLogging(debug bool) {
 		NoColor:    true})
 }
 
+func printVersionString() string {
+	return fmt.Sprintf("ib-kubernetes version:%s, commit:%s, date:%s", version, commit, date)
+}
+
 func main() {
+	// Init command line flags to clear vendor packages' flags, especially in init()
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
 	var debug bool
+	var versionOpt bool
+	flag.BoolVar(&versionOpt, "version", false, "Show application version")
+	flag.BoolVar(&versionOpt, "v", false, "Show application version")
 	flag.BoolVar(&debug, "debug", false, "Debug level logging")
+
 	flag.Parse()
+	if versionOpt {
+		fmt.Printf("%s\n", printVersionString())
+		return
+	}
 
 	setupLogging(debug)
 


### PR DESCRIPTION
    When run the ib-kubernetes with flag -v or --version it will show
    the branch of the build, commit id, and the build data in the
    format: "ib-kubernetes version:<branch>, commit:<commit id>,
    date:<build-date>"