### PR TITLE
Rename HasNetworkAttachment to HasNetworkAttachmentAnnot

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -33,8 +33,8 @@ func PodScheduled(pod *kapi.Pod) bool {
 	return pod.Spec.NodeName != ""
 }
 
-// HasNetworkAttachment check if pod has Network Attachment
-func HasNetworkAttachment(pod *kapi.Pod) bool {
+// HasNetworkAttachmentAnnot check if pod has Network Attachment Annotation
+func HasNetworkAttachmentAnnot(pod *kapi.Pod) bool {
 	return len(pod.Annotations[v1.NetworkAttachmentAnnot]) > 0
 }
 

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -21,11 +21,11 @@ var _ = Describe("Utils", func() {
 			Expect(PodScheduled(pod)).To(BeTrue())
 		})
 	})
-	Context("HasNetworkAttachment", func() {
+	Context("HasNetworkAttachmentAnnot", func() {
 		It("Check pod if pod is has network attachment annotation", func() {
 			pod := &kapi.Pod{ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{v1.NetworkAttachmentAnnot: `[{"name":"test"}]`}}}
-			Expect(HasNetworkAttachment(pod)).To(BeTrue())
+			Expect(HasNetworkAttachmentAnnot(pod)).To(BeTrue())
 		})
 	})
 	Context("PodIsRunning", func() {

--- a/pkg/watcher/handler/pod.go
+++ b/pkg/watcher/handler/pod.go
@@ -49,7 +49,7 @@ func (p *podEventHandler) OnAdd(obj interface{}) {
 		return
 	}
 
-	if !utils.HasNetworkAttachment(pod) {
+	if !utils.HasNetworkAttachmentAnnot(pod) {
 		log.Debug().Msgf("pod doesn't have network annotation \"%v\"", v1.NetworkAttachmentAnnot)
 		return
 	}
@@ -83,7 +83,7 @@ func (p *podEventHandler) OnUpdate(oldObj, newObj interface{}) {
 		return
 	}
 
-	if !utils.HasNetworkAttachment(pod) {
+	if !utils.HasNetworkAttachmentAnnot(pod) {
 		log.Debug().Msgf("pod doesn't have network annotation \"%v\"", v1.NetworkAttachmentAnnot)
 		return
 	}
@@ -115,7 +115,7 @@ func (p *podEventHandler) OnDelete(obj interface{}) {
 		return
 	}
 
-	if !utils.HasNetworkAttachment(pod) {
+	if !utils.HasNetworkAttachmentAnnot(pod) {
 		log.Debug().Msgf("pod doesn't have network annotation \"%v\"", v1.NetworkAttachmentAnnot)
 		return
 	}


### PR DESCRIPTION
This function actually check network attachment annotations,
not network attachment.

Related: #79 