### PR TITLE
Avoid guid pool exhaustion from guid leaks by syncing it with SM

### DIFF
--- a/pkg/sm/plugins/noop/noop.go
+++ b/pkg/sm/plugins/noop/noop.go
@@ -48,6 +48,11 @@ func (p *plugin) RemoveGuidsFromPKey(pkey int, guids []net.HardwareAddr) error {
 	return nil
 }
 
+func (p *plugin) ListGuidsInUse() ([]string, error) {
+	log.Info().Msg("noop Plugin ListGuidsInUse()")
+	return nil, nil
+}
+
 // Initialize applies configs to plugin and return a subnet manager client
 func Initialize() (plugins.SubnetManagerClient, error) {
 	log.Info().Msg("Initializing noop plugin")

--- a/pkg/sm/plugins/plugin.go
+++ b/pkg/sm/plugins/plugin.go
@@ -19,4 +19,7 @@ type SubnetManagerClient interface {
 	// RemoveGuidsFromPKey remove guids for given pkey.
 	// It return error if failed.
 	RemoveGuidsFromPKey(pkey int, guids []net.HardwareAddr) error
+
+	// ListGuidsInUse returns a list of all GUIDS associated with PKeys
+	ListGuidsInUse() ([]string, error)
 }

--- a/pkg/sm/plugins/ufm/ufm_test.go
+++ b/pkg/sm/plugins/ufm/ufm_test.go
@@ -152,4 +152,43 @@ var _ = Describe("Ufm Subnet Manager Client plugin", func() {
 			Expect(&errMsg).To(Equal(&errMessage))
 		})
 	})
+	Context("ListGuidsInUse", func() {
+		It("Remove guid from valid pkey", func() {
+			testResponse := `{
+				"0x7fff": {
+					"guids": []
+				},
+				"0x7aff": {
+					"test": "val"
+				},
+				"0x5": {
+					"guids": [
+						{
+							"guid": "020000000000003e"
+						},
+						{
+							"guid": "02000FF000FF0009"
+						}
+					]
+				},
+				"0x6": {
+					"guids": [
+						{
+							"guid": "0200000000000000"
+						}
+					]
+				}
+			}`
+
+			client := &mocks.Client{}
+			client.On("Get", mock.Anything, mock.Anything).Return([]byte(testResponse), nil)
+
+			plugin := &ufmPlugin{client: client, conf: UFMConfig{}}
+			guids, err := plugin.ListGuidsInUse()
+			Expect(err).ToNot(HaveOccurred())
+
+			expectedGuids := []string{"02:00:00:00:00:00:00:3e", "02:00:0F:F0:00:FF:00:09", "02:00:00:00:00:00:00:00"}
+			Expect(guids).To(ConsistOf(expectedGuids))
+		})
+	})
 })


### PR DESCRIPTION
If the node running pods that use ib network is restarted, those pods'
 GUID are deleted from UFM but are persisted in ib-kubernetes.
They become unusable and might exhaust the GUID pool if it's configured to be small enough.
The solution is to sync guid pool with UFM because some GUIDs might have become free to use.

Signed-off-by: amaslennikov <amaslennikov@nvidia.com>