### PR TITLE
Change ib-kubernetes update strategy to Recreate

### DIFF
--- a/deployment/ib-kubernetes.yaml
+++ b/deployment/ib-kubernetes.yaml
@@ -42,7 +42,7 @@ metadata:
 spec:
   progressDeadlineSeconds: 600
   strategy:
-    type: RollingUpdate
+    type: Recreate
   replicas: 1
   selector:
     matchLabels:
@@ -82,15 +82,6 @@ spec:
                     operator: In
                     values:
                       - "linux"
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchExpressions:
-                  - key: name
-                    operator: In
-                    values:
-                      - ib-kubernetes
-              topologyKey: kubernetes.io/hostname
       containers:
         - name: ib-kubernetes
           image: mellanox/ib-kubernetes


### PR DESCRIPTION
When RollingUpdate strategy is used, the old pod is only deleted, when the new pod gets to the running state to reduce the downtime. https://kubernetes.io/docs/tutorials/kubernetes-basics/update/update-intro/ However, for ib-kubernetes we specified the anti affinity, which prevent two ib-kubernetes pods running on the same node. In this case, when the deployment is updated, the new pod is forever pending because the old one is not deleted.

To fix this, changing the update strategy to Recreate.

As part of this change, drop the PodAntiAffinity as it doesn't bring any useful impact on the deployment.