### PR TITLE
chore: fix Docker file casing warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24 as builder
+FROM golang:1.24 AS builder
 
 WORKDIR /workspace
 ADD ./go.mod ./


### PR DESCRIPTION
Fixes:
![image](https://github.com/user-attachments/assets/6ee4ae78-6732-44da-b8da-52c247daa3e8)
