### PR TITLE
NAD: add-only support without pod restart

### DIFF
--- a/deployment/ib-kubernetes.yaml
+++ b/deployment/ib-kubernetes.yaml
@@ -15,7 +15,7 @@ rules:
     verbs: ["get", "list", "patch", "watch"]
   - apiGroups: ["k8s.cni.cncf.io"]
     resources: ["*"]
-    verbs: ["get"]
+    verbs: ["get", "list", "watch"]
   # Leader election permissions
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]

--- a/pkg/k8s-client/client.go
+++ b/pkg/k8s-client/client.go
@@ -40,6 +40,7 @@ type Client interface {
 	GetNetworkAttachmentDefinition(namespace, name string) (*netapi.NetworkAttachmentDefinition, error)
 	GetRestClient() rest.Interface
 	GetCoordinationV1() coordv1client.CoordinationV1Interface
+	GetNetClient() netclient.K8sCniCncfIoV1Interface
 }
 
 type client struct {
@@ -119,4 +120,9 @@ func (c *client) GetRestClient() rest.Interface {
 // GetCoordinationV1 returns the coordination v1 client for leader election
 func (c *client) GetCoordinationV1() coordv1client.CoordinationV1Interface {
 	return c.clientset.CoordinationV1()
+}
+
+// GetNetClient returns the network attachment definition client for NAD watcher
+func (c *client) GetNetClient() netclient.K8sCniCncfIoV1Interface {
+	return c.netClient
 }

--- a/pkg/k8s-client/mocks/Client.go
+++ b/pkg/k8s-client/mocks/Client.go
@@ -3,8 +3,10 @@
 package mocks
 
 import (
-	k8s_cni_cncf_iov1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	apisk8s_cni_cncf_iov1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	corev1 "k8s.io/api/core/v1"
+
+	k8s_cni_cncf_iov1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
 
 	mock "github.com/stretchr/testify/mock"
 
@@ -40,24 +42,44 @@ func (_m *Client) GetCoordinationV1() v1.CoordinationV1Interface {
 	return r0
 }
 
+// GetNetClient provides a mock function with no fields
+func (_m *Client) GetNetClient() k8s_cni_cncf_iov1.K8sCniCncfIoV1Interface {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetNetClient")
+	}
+
+	var r0 k8s_cni_cncf_iov1.K8sCniCncfIoV1Interface
+	if rf, ok := ret.Get(0).(func() k8s_cni_cncf_iov1.K8sCniCncfIoV1Interface); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(k8s_cni_cncf_iov1.K8sCniCncfIoV1Interface)
+		}
+	}
+
+	return r0
+}
+
 // GetNetworkAttachmentDefinition provides a mock function with given fields: namespace, name
-func (_m *Client) GetNetworkAttachmentDefinition(namespace string, name string) (*k8s_cni_cncf_iov1.NetworkAttachmentDefinition, error) {
+func (_m *Client) GetNetworkAttachmentDefinition(namespace string, name string) (*apisk8s_cni_cncf_iov1.NetworkAttachmentDefinition, error) {
 	ret := _m.Called(namespace, name)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetNetworkAttachmentDefinition")
 	}
 
-	var r0 *k8s_cni_cncf_iov1.NetworkAttachmentDefinition
+	var r0 *apisk8s_cni_cncf_iov1.NetworkAttachmentDefinition
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string, string) (*k8s_cni_cncf_iov1.NetworkAttachmentDefinition, error)); ok {
+	if rf, ok := ret.Get(0).(func(string, string) (*apisk8s_cni_cncf_iov1.NetworkAttachmentDefinition, error)); ok {
 		return rf(namespace, name)
 	}
-	if rf, ok := ret.Get(0).(func(string, string) *k8s_cni_cncf_iov1.NetworkAttachmentDefinition); ok {
+	if rf, ok := ret.Get(0).(func(string, string) *apisk8s_cni_cncf_iov1.NetworkAttachmentDefinition); ok {
 		r0 = rf(namespace, name)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*k8s_cni_cncf_iov1.NetworkAttachmentDefinition)
+			r0 = ret.Get(0).(*apisk8s_cni_cncf_iov1.NetworkAttachmentDefinition)
 		}
 	}
 

--- a/pkg/watcher/handler/nad.go
+++ b/pkg/watcher/handler/nad.go
@@ -1,0 +1,111 @@
+// Copyright 2025 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	v1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	"github.com/rs/zerolog/log"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/Mellanox/ib-kubernetes/pkg/utils"
+)
+
+type NADEventHandler struct {
+	addedNADs *utils.SynchronizedMap // Maps network ID to NAD for added NADs
+	nadCache  sync.Map               // Cache of current NADs by namespace/name
+}
+
+// NewNADEventHandler creates a new NAD event handler
+func NewNADEventHandler() ResourceEventHandler {
+	return &NADEventHandler{
+		addedNADs: utils.NewSynchronizedMap(),
+		nadCache:  sync.Map{},
+	}
+}
+
+// GetResourceObject returns the NAD object type for the watcher
+func (n *NADEventHandler) GetResourceObject() runtime.Object {
+	return &v1.NetworkAttachmentDefinition{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "NetworkAttachmentDefinition",
+			APIVersion: "k8s.cni.cncf.io/v1",
+		},
+	}
+}
+
+// OnAdd handles NAD creation events
+func (n *NADEventHandler) OnAdd(obj interface{}, _ bool) {
+	nad := obj.(*v1.NetworkAttachmentDefinition)
+	log.Info().Msgf("NAD add event: namespace %s name %s", nad.Namespace, nad.Name)
+
+	// Only handle InfiniBand SR-IOV networks
+	if !n.isInfiniBandNetwork(nad) {
+		log.Debug().Msgf("NAD %s/%s is not an InfiniBand network", nad.Namespace, nad.Name)
+		return
+	}
+
+	networkID := fmt.Sprintf("%s_%s", nad.Namespace, nad.Name)
+
+	// Cache the NAD for future reference
+	n.nadCache.Store(networkID, nad)
+
+	// Add to processing queue
+	n.addedNADs.Set(networkID, nad)
+
+	log.Info().Msgf("Successfully processed NAD add event: %s", networkID)
+}
+
+// OnUpdate is a no-op for add-only support
+func (n *NADEventHandler) OnUpdate(oldObj, newObj interface{}) {}
+
+// OnDelete is a no-op for add-only support
+func (n *NADEventHandler) OnDelete(obj interface{}) {}
+
+// GetResults returns the results maps for processing by the daemon
+func (n *NADEventHandler) GetResults() (*utils.SynchronizedMap, *utils.SynchronizedMap) {
+	return n.addedNADs, nil
+}
+
+// GetNADFromCache retrieves a cached NAD by network ID
+func (n *NADEventHandler) GetNADFromCache(networkID string) (*v1.NetworkAttachmentDefinition, bool) {
+	if nad, ok := n.nadCache.Load(networkID); ok {
+		return nad.(*v1.NetworkAttachmentDefinition), true
+	}
+	return nil, false
+}
+
+// isInfiniBandNetwork checks if the NAD is for InfiniBand SR-IOV
+func (n *NADEventHandler) isInfiniBandNetwork(nad *v1.NetworkAttachmentDefinition) bool {
+	// Parse the network configuration
+	var networkConfig map[string]interface{}
+	if err := json.Unmarshal([]byte(nad.Spec.Config), &networkConfig); err != nil {
+		log.Error().Msgf("Failed to parse NAD config for %s/%s: %v", nad.Namespace, nad.Name, err)
+		return false
+	}
+
+	// Check if this is an ib-sriov network
+	if cniType, ok := networkConfig["type"]; ok {
+		return cniType == utils.InfiniBandSriovCni
+	}
+
+	return false
+}

--- a/pkg/watcher/handler/nad_test.go
+++ b/pkg/watcher/handler/nad_test.go
@@ -1,0 +1,125 @@
+// Copyright 2025 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package handler
+
+import (
+	v1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("NAD Event Handler", func() {
+	var nadHandler ResourceEventHandler
+
+	BeforeEach(func() {
+		nadHandler = NewNADEventHandler()
+	})
+
+	Describe("GetResourceObject", func() {
+		It("should return NetworkAttachmentDefinition resource object", func() {
+			resource := nadHandler.GetResourceObject()
+			Expect(resource).ToNot(BeNil())
+
+			nad, ok := resource.(*v1.NetworkAttachmentDefinition)
+			Expect(ok).To(BeTrue())
+			Expect(nad.Kind).To(Equal("NetworkAttachmentDefinition"))
+			Expect(nad.APIVersion).To(Equal("k8s.cni.cncf.io/v1"))
+		})
+	})
+
+	Describe("OnAdd", func() {
+		Context("with InfiniBand SR-IOV NAD", func() {
+			It("should process the NAD add event", func() {
+				nad := &v1.NetworkAttachmentDefinition{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-ib-network",
+						Namespace: "default",
+					},
+					Spec: v1.NetworkAttachmentDefinitionSpec{
+						Config: `{"type": "ib-sriov", "pkey": "0x7fff"}`,
+					},
+				}
+
+				nadHandler.OnAdd(nad, false)
+
+				addedNADs, _ := nadHandler.GetResults()
+				networkID := "default_test-ib-network"
+
+				result, exists := addedNADs.Get(networkID)
+				Expect(exists).To(BeTrue())
+				Expect(result).To(Equal(nad))
+			})
+		})
+
+		Context("with non-InfiniBand NAD", func() {
+			It("should ignore the NAD add event", func() {
+				nad := &v1.NetworkAttachmentDefinition{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-other-network",
+						Namespace: "default",
+					},
+					Spec: v1.NetworkAttachmentDefinitionSpec{
+						Config: `{"type": "sriov"}`,
+					},
+				}
+
+				nadHandler.OnAdd(nad, false)
+
+				addedNADs, _ := nadHandler.GetResults()
+				networkID := "default_test-other-network"
+
+				_, exists := addedNADs.Get(networkID)
+				Expect(exists).To(BeFalse())
+			})
+		})
+	})
+
+	// Note: Only NAD add functionality is tested as update/delete operations are not supported
+
+	Describe("GetNADFromCache", func() {
+		It("should retrieve cached NAD", func() {
+			nad := &v1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ib-network",
+					Namespace: "default",
+				},
+				Spec: v1.NetworkAttachmentDefinitionSpec{
+					Config: `{"type": "ib-sriov", "pkey": "0x7fff"}`,
+				},
+			}
+
+			// First add the NAD
+			nadHandler.OnAdd(nad, false)
+
+			// Then retrieve from cache
+			nadHandlerImpl := nadHandler.(*NADEventHandler)
+			cachedNAD, exists := nadHandlerImpl.GetNADFromCache("default_test-ib-network")
+
+			Expect(exists).To(BeTrue())
+			Expect(cachedNAD).To(Equal(nad))
+		})
+
+		It("should return false for non-existent NAD", func() {
+			nadHandlerImpl := nadHandler.(*NADEventHandler)
+			_, exists := nadHandlerImpl.GetNADFromCache("nonexistent/network")
+
+			Expect(exists).To(BeFalse())
+		})
+	})
+})


### PR DESCRIPTION
- Process only NAD add events and cache them for lookups (no update/delete handling)
- NAD OnUpdate/OnDelete are no-ops

Closes: https://github.com/Mellanox/ib-kubernetes/issues/159