### PR TITLE
Fix GUID cleanup regression for multi-interface pods

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -74,6 +74,11 @@ type podNetworkInfo struct {
 	addr      net.HardwareAddr // GUID allocated for ibNetwork and saved as net.HardwareAddr
 }
 
+type podGUIDInfo struct {
+	addr         net.HardwareAddr
+	podNetworkID string
+}
+
 type networksMap struct {
 	theMap map[types.UID][]*v1.NetworkSelectionElement
 }
@@ -385,14 +390,11 @@ func (d *daemon) processPodsForNetwork(
 		}
 
 		// Process each network interface separately
-		for i, pi := range podNetworkInfos {
-			interfaceName := pi.ibNetwork.InterfaceRequest
-			if interfaceName == "" {
-				interfaceName = fmt.Sprintf("idx_%d", i)
-			}
+		for _, pi := range podNetworkInfos {
+			interfaceName := utils.GetPodNetworkInterfaceName(pi.networks, pi.ibNetwork)
 			log.Debug().Msgf("processing interface %s for network %s on pod %s", interfaceName, networkName, pod.Name)
 
-			if err = d.processNetworkGUID(networkName, ibCniSpec, pi, i); err != nil {
+			if err = d.processNetworkGUID(networkName, ibCniSpec, pi); err != nil {
 				log.Error().Msgf("failed to process network GUID for interface %s: %v", interfaceName, err)
 				continue
 			}
@@ -430,20 +432,10 @@ func (d *daemon) allocatePodNetworkGUID(allocatedGUID, podNetworkID string, podU
 }
 
 // Allocate network GUID, update Pod's networks annotation and add GUID to the podNetworkInfo instance
-func (d *daemon) processNetworkGUID(
-	networkID string, spec *utils.IbSriovCniSpec, pi *podNetworkInfo, interfaceIndex int,
-) error {
+func (d *daemon) processNetworkGUID(networkID string, spec *utils.IbSriovCniSpec, pi *podNetworkInfo) error {
 	var guidAddr guid.GUID
 	allocatedGUID, err := utils.GetPodNetworkGUID(pi.ibNetwork)
-
-	// Generate unique ID per interface to handle multiple interfaces with same network name
-	var interfaceName string
-	if pi.ibNetwork.InterfaceRequest != "" {
-		interfaceName = pi.ibNetwork.InterfaceRequest
-	} else {
-		// Use interface index if interface name is not available
-		interfaceName = fmt.Sprintf("idx_%d", interfaceIndex)
-	}
+	interfaceName := utils.GetPodNetworkInterfaceName(pi.networks, pi.ibNetwork)
 	podNetworkID := utils.GeneratePodNetworkInterfaceID(pi.pod, networkID, interfaceName)
 	if err == nil {
 		// User allocated guid manually or Pod's network was rescheduled
@@ -665,8 +657,8 @@ func (d *daemon) AddPeriodicUpdate() {
 	log.Info().Msg("add periodic update finished")
 }
 
-// get all GUIDs from Pod's networks with the same name (handles multiple interfaces)
-func getAllPodGUIDsForNetwork(pod *kapi.Pod, networkName string) ([]net.HardwareAddr, error) {
+// get all GUIDs and their interface-aware podNetworkIDs from Pod networks with the same name
+func getAllPodGUIDInfosForNetwork(pod *kapi.Pod, networkName string) ([]podGUIDInfo, error) {
 	networks, netErr := netAttUtils.ParsePodNetworkAnnotation(pod)
 	if netErr != nil {
 		return nil, fmt.Errorf("failed to read pod networkName annotations pod namespace %s name %s, with error: %v",
@@ -678,7 +670,7 @@ func getAllPodGUIDsForNetwork(pod *kapi.Pod, networkName string) ([]net.Hardware
 		return nil, fmt.Errorf("failed to get pod networkName specs %s with error: %v", networkName, netErr)
 	}
 
-	guidAddrs := make([]net.HardwareAddr, 0, len(matchingNetworks))
+	guidInfos := make([]podGUIDInfo, 0, len(matchingNetworks))
 	for _, network := range matchingNetworks {
 		if !utils.IsPodNetworkConfiguredWithInfiniBand(network) {
 			log.Debug().Msgf("network %+v is not InfiniBand configured, skipping", network)
@@ -697,10 +689,18 @@ func getAllPodGUIDsForNetwork(pod *kapi.Pod, networkName string) ([]net.Hardware
 			continue
 		}
 
-		guidAddrs = append(guidAddrs, guidAddr)
+		podNetworkID := utils.GeneratePodNetworkInterfaceID(
+			pod,
+			networkName,
+			utils.GetPodNetworkInterfaceName(networks, network),
+		)
+		guidInfos = append(guidInfos, podGUIDInfo{
+			addr:         guidAddr,
+			podNetworkID: podNetworkID,
+		})
 	}
 
-	return guidAddrs, nil
+	return guidInfos, nil
 }
 
 //nolint:nilerr
@@ -733,27 +733,26 @@ func (d *daemon) DeletePeriodicUpdate() {
 		for _, pod := range pods {
 			log.Debug().Msgf("pod namespace %s name %s", pod.Namespace, pod.Name)
 
-			// Get all GUIDs for all interfaces with the same network name
-			var podGUIDs []net.HardwareAddr
-			podGUIDs, err = getAllPodGUIDsForNetwork(pod, networkName)
+			// Get all GUIDs and stable podNetworkIDs for all interfaces with the same network name
+			var podGUIDInfos []podGUIDInfo
+			podGUIDInfos, err = getAllPodGUIDInfosForNetwork(pod, networkName)
 			if err != nil {
 				log.Error().Msgf("%v", err)
 				continue
 			}
 
 			// Process each GUID from the pod
-			for _, guidAddr := range podGUIDs {
-				podNetworkID := utils.GeneratePodNetworkID(pod, networkName)
-				if guidPodEntry, exist := d.guidPodNetworkMap[guidAddr.String()]; exist {
-					if podNetworkID == guidPodEntry {
-						log.Info().Msgf("matched guid %s to pod %s, removing", guidAddr, guidPodEntry)
-						guidList = append(guidList, guidAddr)
+			for _, podGUIDInfo := range podGUIDInfos {
+				if guidPodEntry, exist := d.guidPodNetworkMap[podGUIDInfo.addr.String()]; exist {
+					if podGUIDInfo.podNetworkID == guidPodEntry {
+						log.Info().Msgf("matched guid %s to pod %s, removing", podGUIDInfo.addr, guidPodEntry)
+						guidList = append(guidList, podGUIDInfo.addr)
 					} else {
 						log.Warn().Msgf("guid %s is allocated to another pod %s not %s, not removing",
-							guidAddr, guidPodEntry, podNetworkID)
+							podGUIDInfo.addr, guidPodEntry, podGUIDInfo.podNetworkID)
 					}
 				} else {
-					log.Warn().Msgf("guid %s is not allocated to any pod on delete", guidAddr)
+					log.Warn().Msgf("guid %s is not allocated to any pod on delete", podGUIDInfo.addr)
 				}
 			}
 		}
@@ -894,7 +893,11 @@ func (d *daemon) initGUIDPool() error {
 				continue
 			}
 
-			podNetworkID := string(pod.UID) + network.Name
+			podNetworkID := utils.GeneratePodNetworkInterfaceID(
+				&pod,
+				network.Name,
+				utils.GetPodNetworkInterfaceName(networks, network),
+			)
 			if _, exist := d.guidPodNetworkMap[podGUID]; exist {
 				if podNetworkID != d.guidPodNetworkMap[podGUID] {
 					return fmt.Errorf("failed to allocate requested guid %s, already allocated for %s",

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/Mellanox/ib-kubernetes/pkg/config"
 	"github.com/Mellanox/ib-kubernetes/pkg/guid"
 	k8sMocks "github.com/Mellanox/ib-kubernetes/pkg/k8s-client/mocks"
+	"github.com/Mellanox/ib-kubernetes/pkg/utils"
+	v1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	kapi "k8s.io/api/core/v1"
@@ -166,6 +168,33 @@ var _ = Describe("Daemon", func() {
 			err := testDaemon.allocatePodNetworkGUID("invalid-guid", testNetworkID, testUID, testPKey)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to allocate GUID"))
+		})
+	})
+
+	Context("getAllPodGUIDInfosForNetwork", func() {
+		It("returns interface-aware pod network IDs for duplicate network names", func() {
+			pod := &kapi.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       "multi-pod",
+					Name:      "multi-pod",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"k8s.v1.cni.cncf.io/networks": `[{"name":"ib-sriov-network","namespace":"default","cni-args":{"guid":"02:00:00:00:00:00:00:21","pkey":"0x7fff","mellanox.infiniband.app":"configured"}},{"name":"ib-sriov-network","namespace":"default","cni-args":{"guid":"02:00:00:00:00:00:00:22","pkey":"0x7fff","mellanox.infiniband.app":"configured"}}]`,
+					},
+				},
+			}
+
+			guidInfos, err := getAllPodGUIDInfosForNetwork(pod, "ib-sriov-network")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(guidInfos).To(HaveLen(2))
+			Expect(guidInfos[0].addr.String()).To(Equal("02:00:00:00:00:00:00:21"))
+			Expect(guidInfos[0].podNetworkID).To(Equal(
+				utils.GeneratePodNetworkInterfaceID(pod, "ib-sriov-network", "idx_0"),
+			))
+			Expect(guidInfos[1].addr.String()).To(Equal("02:00:00:00:00:00:00:22"))
+			Expect(guidInfos[1].podNetworkID).To(Equal(
+				utils.GeneratePodNetworkInterfaceID(pod, "ib-sriov-network", "idx_1"),
+			))
 		})
 	})
 
@@ -386,6 +415,45 @@ var _ = Describe("Daemon", func() {
 
 			err := testDaemon.initGUIDPool()
 			Expect(err).ToNot(HaveOccurred())
+
+			mockK8sClient.AssertExpectations(GinkgoT())
+		})
+
+		It("uses the same interface-aware IDs as processNetworkGUID after restart", func() {
+			pod := &kapi.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       "multi-pod",
+					Name:      "multi-pod",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"k8s.v1.cni.cncf.io/networks": `[{"name":"ib-sriov-network","namespace":"default","cni-args":{"guid":"02:00:00:00:00:00:00:31","pkey":"0x7fff","mellanox.infiniband.app":"configured"}},{"name":"ib-sriov-network","namespace":"default","cni-args":{"guid":"02:00:00:00:00:00:00:32","pkey":"0x7fff","mellanox.infiniband.app":"configured"}}]`,
+					},
+				},
+				Status: kapi.PodStatus{
+					Phase: kapi.PodRunning,
+				},
+			}
+
+			podList := &kapi.PodList{Items: []kapi.Pod{*pod}}
+			mockK8sClient.On("GetPods", kapi.NamespaceAll).Return(podList, nil)
+			mockClient.listGuidsInUseResult = map[string]string{
+				"02:00:00:00:00:00:00:31": "0x7fff",
+				"02:00:00:00:00:00:00:32": "0x7fff",
+			}
+
+			err := testDaemon.initGUIDPool()
+			Expect(err).ToNot(HaveOccurred())
+
+			netMap := networksMap{theMap: make(map[types.UID][]*v1.NetworkSelectionElement)}
+			podNetworkInfos, err := getAllPodNetworkInfos("ib-sriov-network", pod, netMap)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(podNetworkInfos).To(HaveLen(2))
+
+			spec := &utils.IbSriovCniSpec{PKey: "0x7fff"}
+			for _, pi := range podNetworkInfos {
+				err = testDaemon.processNetworkGUID("ib-sriov-network", spec, pi)
+				Expect(err).ToNot(HaveOccurred())
+			}
 
 			mockK8sClient.AssertExpectations(GinkgoT())
 		})
@@ -644,6 +712,7 @@ var _ = Describe("Daemon", func() {
 				ContainSubstring("configuration"),
 				ContainSubstring("k8s"),
 				ContainSubstring("client"),
+				ContainSubstring("plugin"),
 			))
 		})
 	})

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -219,6 +219,34 @@ func GetAllPodNetworks(
 	return matchingNetworks, nil
 }
 
+// GetPodNetworkInterfaceName returns a stable per-interface name for a pod network.
+// When InterfaceRequest is empty, it falls back to the occurrence index among
+// networks with the same name so init, add, and delete all derive the same ID.
+func GetPodNetworkInterfaceName(
+	networks []*v1.NetworkSelectionElement, targetNetwork *v1.NetworkSelectionElement,
+) string {
+	if targetNetwork == nil {
+		return ""
+	}
+
+	if targetNetwork.InterfaceRequest != "" {
+		return targetNetwork.InterfaceRequest
+	}
+
+	sameNameIndex := 0
+	for _, network := range networks {
+		if network.Name != targetNetwork.Name {
+			continue
+		}
+		if network == targetNetwork {
+			return fmt.Sprintf("idx_%d", sameNameIndex)
+		}
+		sameNameIndex++
+	}
+
+	return "idx_0"
+}
+
 // ParsePKey returns parsed PKey from string
 func ParsePKey(pKey string) (int, error) {
 	match := regexp.MustCompile(`0[xX][0-9a-fA-F]+`)

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -358,6 +358,33 @@ var _ = Describe("Utils", func() {
 			Expect(err).To(HaveOccurred())
 		})
 	})
+	Context("GetPodNetworkInterfaceName", func() {
+		It("returns the explicit interface request when present", func() {
+			networks := []*v1.NetworkSelectionElement{
+				{Name: "ib-vf-network", InterfaceRequest: "net1"},
+			}
+
+			interfaceName := GetPodNetworkInterfaceName(networks, networks[0])
+
+			Expect(interfaceName).To(Equal("net1"))
+		})
+
+		It("uses the same-name occurrence index for unnamed interfaces", func() {
+			networks := []*v1.NetworkSelectionElement{
+				{Name: "ib-vf-network", InterfaceRequest: "net1"},
+				{Name: "other-network", InterfaceRequest: "eth1"},
+				{Name: "ib-vf-network"},
+				{Name: "ib-vf-network", InterfaceRequest: "net3"},
+				{Name: "ib-vf-network"},
+			}
+
+			firstUnnamed := GetPodNetworkInterfaceName(networks, networks[2])
+			secondUnnamed := GetPodNetworkInterfaceName(networks, networks[4])
+
+			Expect(firstUnnamed).To(Equal("idx_1"))
+			Expect(secondUnnamed).To(Equal("idx_3"))
+		})
+	})
 	Context("GeneratePodNetworkInterfaceID", func() {
 		It("should generate unique ID with interface name", func() {
 			pod := &kapi.Pod{


### PR DESCRIPTION
  Summary

  Fix inconsistent podNetworkID derivation introduced by #161 (Support multiple network interfaces per pod).

  Closes #207

  Problem

  processNetworkGUID() allocates and tracks GUID ownership using an interface-aware key (GeneratePodNetworkInterfaceID), but DeletePeriodicUpdate() matched using GeneratePodNetworkID and initGUIDPool() rebuilt entries using
  string(pod.UID) + network.Name.

  These identifiers are not equivalent for pods with multiple interfaces using the same NAD name, causing GUIDs to leak on delete and restart.

  Fix

  Introduce a shared GetPodNetworkInterfaceName helper that derives a stable per-interface name (uses InterfaceRequest when present, otherwise idx_N from occurrence index). All three paths now use this helper consistently:

  - add path (processNetworkGUID)
  - delete path (getAllPodGUIDInfosForNetwork)
  - init/restart path (initGUIDPool)

  Testing

  - Regression test confirms old code fails to match GUIDs for multi-interface pods
  - Init/restart consistency test verifies initGUIDPool + processNetworkGUID agree on IDs
  - GetPodNetworkInterfaceName unit tests for named and unnamed interface fallback
