### PR TITLE
feat(daemon): add FabricClient support for IB partitions and PF GUIDs

### DIFF
--- a/deployment/ib-kubernetes.yaml
+++ b/deployment/ib-kubernetes.yaml
@@ -15,7 +15,7 @@ rules:
     verbs: ["get", "list", "patch", "watch"]
   - apiGroups: ["k8s.cni.cncf.io"]
     resources: ["*"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   # Leader election permissions
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -18,24 +18,15 @@ package daemon
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
-	"net"
 	"os"
 	"os/signal"
 	"path"
-	"sync"
 	"syscall"
 	"time"
 
-	v1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
-	netAttUtils "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/utils"
 	"github.com/rs/zerolog/log"
-	kapi "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
@@ -45,7 +36,6 @@ import (
 	k8sClient "github.com/Mellanox/ib-kubernetes/pkg/k8s-client"
 	"github.com/Mellanox/ib-kubernetes/pkg/sm"
 	"github.com/Mellanox/ib-kubernetes/pkg/sm/plugins"
-	"github.com/Mellanox/ib-kubernetes/pkg/utils"
 	"github.com/Mellanox/ib-kubernetes/pkg/watcher"
 	resEvenHandler "github.com/Mellanox/ib-kubernetes/pkg/watcher/handler"
 )
@@ -55,36 +45,14 @@ type Daemon interface {
 	Run()
 }
 
+// daemon is the top-level wiring: config + plugin load + leader election +
+// the two controllers. All reconciliation lives in partitionController and
+// podController; daemon only orchestrates start/stop.
 type daemon struct {
-	config            config.DaemonConfig
-	podWatcher        watcher.Watcher
-	nadWatcher        watcher.Watcher // NAD watcher for network definition changes
-	kubeClient        k8sClient.Client
-	guidPool          guid.Pool
-	smClient          plugins.SubnetManagerClient
-	fabricClient      plugins.FabricClient // nil if plugin does not implement FabricClient
-	guidPodNetworkMap map[string]string    // allocated guid mapped to the pod and network
-
-	// NAD caches — sync.Map for concurrent access from AddPeriodicUpdate + ProcessNADChanges goroutines.
-	nadCache              sync.Map // network ID (string) -> *v1.NetworkAttachmentDefinition
-	partitionManagedCache sync.Map // network ID (string) -> bool
-}
-
-// Temporary struct used to proceed pods' networks
-type podNetworkInfo struct {
-	pod       *kapi.Pod
-	ibNetwork *v1.NetworkSelectionElement
-	networks  []*v1.NetworkSelectionElement
-	addr      net.HardwareAddr // GUID allocated for ibNetwork and saved as net.HardwareAddr
-}
-
-type podGUIDInfo struct {
-	addr         net.HardwareAddr
-	podNetworkID string
-}
-
-type networksMap struct {
-	theMap map[types.UID][]*v1.NetworkSelectionElement
+	config        config.DaemonConfig
+	kubeClient    k8sClient.Client
+	podCtrl       *podController
+	partitionCtrl *partitionController
 }
 
 // Exponential backoff ~26 sec + 6 * <api call time>
@@ -93,24 +61,10 @@ type networksMap struct {
 // NOTE: ufm client has default timeout on request operation for 30 seconds.
 var backoffValues = wait.Backoff{Duration: 1 * time.Second, Factor: 1.6, Jitter: 0.1, Steps: 6}
 
-// Return networks mapped to the pod. If mapping not exist it is created
-func (n *networksMap) getPodNetworks(pod *kapi.Pod) ([]*v1.NetworkSelectionElement, error) {
-	var err error
-	networks, ok := n.theMap[pod.UID]
-	if !ok {
-		networks, err = netAttUtils.ParsePodNetworkAnnotation(pod)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read pod networkName annotations pod namespace %s name %s, with error: %v",
-				pod.Namespace, pod.Name, err)
-		}
-
-		n.theMap[pod.UID] = networks
-	}
-	return networks, nil
-}
-
-// NewDaemon initializes the need components including k8s client, subnet manager client plugins, and guid pool.
-// It returns error in case of failure.
+// NewDaemon initializes the daemon: config, k8s client, SM plugin, GUID pool,
+// pod + NAD watchers, and the two controllers. Construction is two-step so
+// the controllers can satisfy each other's dependencies before either
+// goroutine starts.
 func NewDaemon() (Daemon, error) {
 	daemonConfig := config.DaemonConfig{}
 	if err := daemonConfig.ReadConfig(); err != nil {
@@ -140,7 +94,8 @@ func NewDaemon() (Daemon, error) {
 		return nil, err
 	}
 
-	// Check if plugin implements FabricClient (optional interface for partition-aware plugins)
+	// Plugins that implement FabricClient drive partition-aware paths;
+	// others (UFM, noop) stay on the legacy GUID pool flow.
 	var fabricClient plugins.FabricClient
 	if pc, ok := smClient.(plugins.FabricClient); ok {
 		fabricClient = pc
@@ -168,16 +123,21 @@ func NewDaemon() (Daemon, error) {
 	podWatcher := watcher.NewWatcher(podEventHandler, client)
 	nadWatcher := watcher.NewWatcher(nadEventHandler, client)
 
-	// Return daemon fully formed
+	// Two-step wiring resolves the mutual dependency between controllers:
+	//   - partitionController needs podController.updatePodNetworkAnnotation
+	//     (passed by value as a method reference)
+	//   - podController needs partitionController as its PartitionReader
+	// Both controllers are constructed before any goroutine starts, so the
+	// post-construction pointer assignment is safe.
+	partitionCtrl := newPartitionController(fabricClient, smClient, client, nadWatcher)
+	podCtrl := newPodController(client, smClient, guidPool, podWatcher, partitionCtrl)
+	partitionCtrl.updatePodAnnotation = podCtrl.updatePodNetworkAnnotation
+
 	return &daemon{
-		config:            daemonConfig,
-		kubeClient:        client,
-		guidPool:          guidPool,
-		smClient:          smClient,
-		fabricClient:      fabricClient,
-		guidPodNetworkMap: make(map[string]string),
-		podWatcher:        podWatcher,
-		nadWatcher:        nadWatcher,
+		config:        daemonConfig,
+		kubeClient:    client,
+		podCtrl:       podCtrl,
+		partitionCtrl: partitionCtrl,
 	}, nil
 }
 
@@ -219,7 +179,6 @@ func (d *daemon) Run() {
 
 	log.Info().Msgf("Starting leader election in namespace: %s with identity: %s", namespace, identity)
 
-	// Create leader election configuration
 	lock := &resourcelock.LeaseLock{
 		LeaseMeta: metav1.ObjectMeta{
 			Name:      "ib-kubernetes-leader",
@@ -238,18 +197,17 @@ func (d *daemon) Run() {
 		RenewDeadline:   30 * time.Second, // Standard Kubernetes components deadline
 		RetryPeriod:     20 * time.Second, // Standard Kubernetes components retry
 		Callbacks: leaderelection.LeaderCallbacks{
-			OnStartedLeading: func(ctx context.Context) {
+			OnStartedLeading: func(_ context.Context) {
 				log.Info().Msgf("Started leading with identity: %s", identity)
 				if err := d.becomeLeader(); err != nil {
 					log.Error().Msgf("Failed to become leader: %v", err)
-					// Cancel context to gracefully release lease and exit
 					cancel()
 					return
 				}
 			},
 			OnStoppedLeading: func() {
 				log.Error().Msgf("Lost leadership unexpectedly, identity: %s", identity)
-				// Leadership lost unexpectedly - force immediate restart for clean state
+				// Force restart for clean state.
 				os.Exit(1)
 			},
 			OnNewLeader: func(leaderIdentity string) {
@@ -262,19 +220,16 @@ func (d *daemon) Run() {
 		},
 	}
 
-	// Start leader election in background
 	leaderElectionDone := make(chan struct{})
 	go func() {
 		defer close(leaderElectionDone)
 		leaderelection.RunOrDie(ctx, leaderElectionConfig)
 	}()
 
-	// Wait for termination signal or leader election completion
 	select {
 	case sig := <-sigChan:
 		log.Info().Msgf("Received signal %s. Terminating...", sig)
-		cancel() // This triggers ReleaseOnCancel
-		// Wait for graceful lease release
+		cancel() // releases lease via ReleaseOnCancel
 		select {
 		case <-leaderElectionDone:
 		case <-time.After(5 * time.Second):
@@ -285,1155 +240,40 @@ func (d *daemon) Run() {
 	}
 }
 
-// becomeLeader is called when this instance becomes the leader
+// becomeLeader runs once when this instance acquires leadership. It rebuilds
+// the GUID pool state from the cluster and then enters the reconciliation
+// loop in runLeaderLogic.
 func (d *daemon) becomeLeader() error {
 	log.Info().Msg("Becoming leader, initializing daemon logic")
 
-	// Initialize the GUID pool (rebuild state from existing pods)
-	if err := d.initGUIDPool(); err != nil {
+	if err := d.podCtrl.initGUIDPool(); err != nil {
 		log.Error().Msgf("initGUIDPool(): Leader could not init the guid pool: %v", err)
 		return fmt.Errorf("failed to initialize GUID pool as leader: %v", err)
 	}
 
-	// Start the actual daemon logic
 	d.runLeaderLogic()
 	return nil
 }
 
-// runLeaderLogic runs the actual daemon operations, only called by the leader
+// runLeaderLogic wires both controllers' periodic ticks and their watchers
+// and blocks until a termination signal. Only the leader runs this.
 func (d *daemon) runLeaderLogic() {
 	log.Info().Msg("Starting leader daemon logic")
 
-	// Run periodic tasks (only leader should do this)
 	stopPeriodicsChan := make(chan struct{})
 
-	go wait.Until(d.AddPeriodicUpdate, time.Duration(d.config.PeriodicUpdate)*time.Second, stopPeriodicsChan)
-	go wait.Until(d.DeletePeriodicUpdate, time.Duration(d.config.PeriodicUpdate)*time.Second, stopPeriodicsChan)
-	go wait.Until(d.ProcessNADChanges, time.Duration(d.config.PeriodicUpdate)*time.Second, stopPeriodicsChan)
+	go wait.Until(d.podCtrl.AddPeriodicUpdate, time.Duration(d.config.PeriodicUpdate)*time.Second, stopPeriodicsChan)
+	go wait.Until(d.podCtrl.DeletePeriodicUpdate, time.Duration(d.config.PeriodicUpdate)*time.Second, stopPeriodicsChan)
+	go wait.Until(d.partitionCtrl.ProcessNADChanges, time.Duration(d.config.PeriodicUpdate)*time.Second, stopPeriodicsChan)
 	defer close(stopPeriodicsChan)
 
-	// Run both watchers in background
-	podWatcherStopFunc := d.podWatcher.RunBackground()
-	nadWatcherStopFunc := d.nadWatcher.RunBackground()
+	podWatcherStopFunc := d.podCtrl.podWatcher.RunBackground()
+	nadWatcherStopFunc := d.partitionCtrl.nadWatcher.RunBackground()
 	defer podWatcherStopFunc()
 	defer nadWatcherStopFunc()
 
-	// Run until interrupted by os signals
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 	sig := <-sigChan
 	log.Info().Msgf("Received signal %s. Terminating...", sig)
-}
-
-// If network identified by networkID is IbSriov return network name and spec
-func (d *daemon) getIbSriovNetwork(networkID string) (string, *utils.IbSriovCniSpec, error) {
-	_, networkName, err := utils.ParseNetworkID(networkID)
-	if err != nil {
-		return "", nil, fmt.Errorf("failed to parse network id %s with error: %v", networkID, err)
-	}
-
-	// Try to get net-attach-def from cache first, then fallback to API
-	netAttInfo, err := d.getCachedNAD(networkID)
-	if err != nil {
-		return "", nil, fmt.Errorf("failed to get network attachment %s: %w", networkName, err)
-	}
-	log.Debug().Msgf("networkName attachment %v", netAttInfo)
-
-	networkSpec := make(map[string]interface{})
-	err = json.Unmarshal([]byte(netAttInfo.Spec.Config), &networkSpec)
-	if err != nil {
-		return "", nil, fmt.Errorf("failed to parse networkName attachment %s with error: %v", networkName, err)
-	}
-	log.Debug().Msgf("networkName attachment spec %+v", networkSpec)
-
-	ibCniSpec, err := utils.GetIbSriovCniFromNetwork(networkSpec)
-	if err != nil {
-		return "", nil, fmt.Errorf(
-			"failed to get InfiniBand SR-IOV CNI spec from network attachment %+v, with error %v",
-			networkSpec, err)
-	}
-
-	log.Debug().Msgf("ib-sriov CNI spec %+v", ibCniSpec)
-	return networkName, ibCniSpec, nil
-}
-
-// getPartitionKeyFromNAD reads the partition PKey from NAD annotation (set by partition-aware plugins)
-func (d *daemon) getPartitionKeyFromNAD(networkID string) string {
-	if val, exists := d.nadCache.Load(networkID); exists {
-		nad := val.(*v1.NetworkAttachmentDefinition)
-		if nad.Annotations != nil {
-			return nad.Annotations[utils.PartitionKeyAnnotation]
-		}
-	}
-	return ""
-}
-
-func (d *daemon) cacheNAD(networkID string, nad *v1.NetworkAttachmentDefinition) {
-	d.nadCache.Store(networkID, nad)
-	d.partitionManagedCache.Store(networkID, isPartitionManagedConfig(networkID, nad.Spec.Config))
-}
-
-func (d *daemon) deleteCachedNAD(networkID string) {
-	d.nadCache.Delete(networkID)
-	d.partitionManagedCache.Delete(networkID)
-}
-
-// isPartitionManagedNAD checks if a NAD has ibKubernetesEnabled set to true,
-// meaning it should be managed via the partition-aware (FabricClient) path.
-func (d *daemon) isPartitionManagedNAD(networkID string) bool {
-	if val, exists := d.partitionManagedCache.Load(networkID); exists {
-		enabled, ok := val.(bool)
-		return ok && enabled
-	}
-
-	val, exists := d.nadCache.Load(networkID)
-	if !exists {
-		return false
-	}
-	nad := val.(*v1.NetworkAttachmentDefinition)
-
-	enabled := isPartitionManagedConfig(networkID, nad.Spec.Config)
-	d.partitionManagedCache.Store(networkID, enabled)
-	return enabled
-}
-
-func isPartitionManagedConfig(networkID, config string) bool {
-	networkSpec := make(map[string]interface{})
-	if err := json.Unmarshal([]byte(config), &networkSpec); err != nil {
-		log.Warn().Str("network_id", networkID).Err(err).Msg("isPartitionManagedNAD: failed to parse NAD config")
-		return false
-	}
-	enabled, ok := networkSpec[utils.IBKubernetesEnabled].(bool)
-	return ok && enabled
-}
-
-// deletePartitionPods removes a node's PF GUIDs from the partition for each deleted pod.
-// Assumes single-pod-per-node-per-partition (fat-VM); a per-(networkID,nodeName) refcount
-// over live pods would be needed before lifting that.
-func (d *daemon) deletePartitionPods(networkID string, pods []*kapi.Pod) {
-	if d.fabricClient == nil {
-		log.Debug().Str("network_id", networkID).Msg("fabric client unavailable, skipping partition delete")
-		return
-	}
-
-	partitionKey := d.getPartitionKeyFromNAD(networkID)
-	if partitionKey == "" {
-		log.Debug().Str("network_id", networkID).Msg("no partition key on NAD, skipping delete")
-		return
-	}
-	pKey, pkeyErr := utils.ParsePKey(partitionKey)
-	if pkeyErr != nil {
-		log.Error().Str("network_id", networkID).Err(pkeyErr).Msg("failed to parse partition key")
-		return
-	}
-
-	for _, pod := range pods {
-		devices, devErr := d.fabricClient.GetNodeIBDevices(pod.Spec.NodeName)
-		if devErr != nil {
-			log.Error().Str("node", pod.Spec.NodeName).Err(devErr).
-				Msg("failed to get IB devices for node on delete")
-			continue
-		}
-		guids := make([]net.HardwareAddr, 0, len(devices))
-		for _, dev := range devices {
-			guids = append(guids, dev.GUID)
-		}
-		if len(guids) > 0 {
-			if rmErr := d.smClient.RemoveGuidsFromPKey(pKey, guids); rmErr != nil {
-				log.Warn().Str("pod", pod.Name).Str("node", pod.Spec.NodeName).
-					Err(rmErr).Msg("failed to remove GUIDs from partition on delete")
-			} else {
-				log.Info().Str("pod", pod.Name).Str("node", pod.Spec.NodeName).
-					Str("pkey", partitionKey).Int("guids", len(guids)).
-					Msg("removed node GUIDs from partition")
-			}
-		}
-	}
-}
-
-// Return pod network info
-// Return all pod network infos for multiple interfaces with same network name
-func getAllPodNetworkInfos(netName string, pod *kapi.Pod, netMap networksMap) ([]*podNetworkInfo, error) {
-	networks, err := netMap.getPodNetworks(pod)
-	if err != nil {
-		return nil, err
-	}
-
-	var matchingNetworks []*v1.NetworkSelectionElement
-	matchingNetworks, err = utils.GetAllPodNetworks(networks, netName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get pod network specs for network %s with error: %v", netName, err)
-	}
-
-	podNetworkInfos := make([]*podNetworkInfo, 0, len(matchingNetworks))
-	for _, network := range matchingNetworks {
-		podNetworkInfos = append(podNetworkInfos, &podNetworkInfo{
-			pod:       pod,
-			networks:  networks,
-			ibNetwork: network,
-		})
-	}
-
-	return podNetworkInfos, nil
-}
-
-// processPodsForNetwork processes all pods and their interfaces for a given network
-func (d *daemon) processPodsForNetwork(
-	pods []*kapi.Pod, networkName string, ibCniSpec *utils.IbSriovCniSpec, netMap networksMap,
-) ([]net.HardwareAddr, []*podNetworkInfo) {
-	var guidList []net.HardwareAddr
-	var passedPods []*podNetworkInfo
-
-	for _, pod := range pods {
-		log.Debug().Msgf("pod namespace %s name %s", pod.Namespace, pod.Name)
-
-		// Get all network interfaces with the same network name
-		podNetworkInfos, err := getAllPodNetworkInfos(networkName, pod, netMap)
-		if err != nil {
-			log.Error().Msgf("%v", err)
-			continue
-		}
-
-		// Process each network interface separately
-		for _, pi := range podNetworkInfos {
-			interfaceName := utils.GetPodNetworkInterfaceName(pi.networks, pi.ibNetwork)
-			log.Debug().Msgf("processing interface %s for network %s on pod %s", interfaceName, networkName, pod.Name)
-
-			if err = d.processNetworkGUID(networkName, ibCniSpec, pi); err != nil {
-				log.Error().Msgf("failed to process network GUID for interface %s: %v", interfaceName, err)
-				continue
-			}
-
-			guidList = append(guidList, pi.addr)
-			passedPods = append(passedPods, pi)
-		}
-	}
-
-	return guidList, passedPods
-}
-
-// Verify if GUID already exist for given network ID and allocates new one if not
-func (d *daemon) allocatePodNetworkGUID(allocatedGUID, podNetworkID string, podUID types.UID, targetPkey string) error {
-	existingPkey, _ := d.guidPool.Get(allocatedGUID)
-	if existingPkey != "" {
-		// This happens when a GUID is being reallocated to a different PKey
-		// (e.g., pod was rescheduled or network configuration changed)
-		if err := d.removeStaleGUID(allocatedGUID, existingPkey); err != nil {
-			log.Warn().Msgf("failed to remove stale GUID %s from pkey %s: %v", allocatedGUID, existingPkey, err)
-		}
-	}
-	if mappedID, exist := d.guidPodNetworkMap[allocatedGUID]; exist {
-		if podNetworkID != mappedID {
-			return fmt.Errorf("failed to allocate requested guid %s, already allocated for %s",
-				allocatedGUID, mappedID)
-		}
-	} else if err := d.guidPool.AllocateGUID(allocatedGUID, targetPkey); err != nil {
-		return fmt.Errorf("failed to allocate GUID for pod ID %s, with error: %v", podUID, err)
-	} else {
-		d.guidPodNetworkMap[allocatedGUID] = podNetworkID
-	}
-
-	return nil
-}
-
-// Allocate network GUID, update Pod's networks annotation and add GUID to the podNetworkInfo instance
-func (d *daemon) processNetworkGUID(networkID string, spec *utils.IbSriovCniSpec, pi *podNetworkInfo) error {
-	var guidAddr guid.GUID
-	allocatedGUID, err := utils.GetPodNetworkGUID(pi.ibNetwork)
-	interfaceName := utils.GetPodNetworkInterfaceName(pi.networks, pi.ibNetwork)
-	podNetworkID := utils.GeneratePodNetworkInterfaceID(pi.pod, networkID, interfaceName)
-	if err == nil {
-		// User allocated guid manually or Pod's network was rescheduled
-		guidAddr, err = guid.ParseGUID(allocatedGUID)
-		if err != nil {
-			return fmt.Errorf("failed to parse user allocated guid %s with error: %v", allocatedGUID, err)
-		}
-
-		err = d.allocatePodNetworkGUID(allocatedGUID, podNetworkID, pi.pod.UID, spec.PKey)
-		if err != nil {
-			return err
-		}
-	} else {
-		guidAddr, err = d.guidPool.GenerateGUID()
-		if err != nil {
-			switch err {
-			// If the guid pool is exhausted, need to sync with SM in case there are unsynced changes
-			case guid.ErrGUIDPoolExhausted:
-				err = d.syncWithSubnetManager()
-				if err != nil {
-					return err
-				}
-			default:
-				return fmt.Errorf("failed to generate GUID for pod ID %s, with error: %v", pi.pod.UID, err)
-			}
-		}
-
-		allocatedGUID = guidAddr.String()
-		err = d.allocatePodNetworkGUID(allocatedGUID, podNetworkID, pi.pod.UID, spec.PKey)
-		if err != nil {
-			return err
-		}
-
-		err = utils.SetPodNetworkGUID(pi.ibNetwork, allocatedGUID, spec.Capabilities["infinibandGUID"])
-		if err != nil {
-			return fmt.Errorf("failed to set pod network guid with error: %v ", err)
-		}
-
-		// Update Pod's network annotation here, so if network will be rescheduled we wouldn't allocate it again
-		netAnnotations, err := json.Marshal(pi.networks)
-		if err != nil {
-			return fmt.Errorf("failed to dump networks %+v of pod into json with error: %v", pi.networks, err)
-		}
-
-		pi.pod.Annotations[v1.NetworkAttachmentAnnot] = string(netAnnotations)
-	}
-
-	// used GUID as net.HardwareAddress to use it in sm plugin which receive []net.HardwareAddress as parameter
-	pi.addr = guidAddr.HardWareAddress()
-	return nil
-}
-
-func (d *daemon) removeStaleGUID(allocatedGUID, existingPkey string) error {
-	parsedPkey, err := utils.ParsePKey(existingPkey)
-	if err != nil {
-		log.Error().Msgf("failed to parse PKey %s with error: %v", existingPkey, err)
-		return err
-	}
-	guidAddr, err := guid.ParseGUID(allocatedGUID)
-	if err != nil {
-		return fmt.Errorf("failed to parse user allocated guid %s with error: %v", allocatedGUID, err)
-	}
-	allocatedGUIDList := []net.HardwareAddr{guidAddr.HardWareAddress()}
-	// Try to remove pKeys via subnet manager in backoff loop
-	if err = wait.ExponentialBackoff(backoffValues, func() (bool, error) {
-		log.Info().Msgf("removing guids of previous pods from pKey %s"+
-			" with subnet manager %s", existingPkey,
-			d.smClient.Name())
-		if err = d.smClient.RemoveGuidsFromPKey(parsedPkey, allocatedGUIDList); err != nil {
-			log.Warn().Msgf("failed to remove guids of removed pods from pKey %s"+
-				" with subnet manager %s with error: %v", existingPkey,
-				d.smClient.Name(), err)
-			return false, nil //nolint:nilerr // retry pattern for exponential backoff
-		}
-		return true, nil
-	}); err != nil {
-		log.Warn().Msgf("failed to remove guids of removed pods from pKey %s"+
-			" with subnet manager %s", existingPkey, d.smClient.Name())
-		return err
-	}
-
-	if err = d.guidPool.ReleaseGUID(allocatedGUID); err != nil {
-		log.Warn().Msgf("failed to release guid \"%s\" with error: %v", allocatedGUID, err)
-		return err
-	}
-	delete(d.guidPodNetworkMap, allocatedGUID)
-	log.Info().Msgf("successfully released %s from pkey %s", allocatedGUID, existingPkey)
-	return nil
-}
-
-// Update and set Pod's network annotation.
-// If failed to update annotation, pod's GUID added into the list to be removed from Pkey.
-func (d *daemon) updatePodNetworkAnnotation(pi *podNetworkInfo, removedList *[]net.HardwareAddr, pkey string) error {
-	if pi.ibNetwork.CNIArgs == nil {
-		pi.ibNetwork.CNIArgs = &map[string]interface{}{}
-	}
-
-	(*pi.ibNetwork.CNIArgs)[utils.InfiniBandAnnotation] = utils.ConfiguredInfiniBandPod
-	if pkey != "" {
-		(*pi.ibNetwork.CNIArgs)[utils.PkeyAnnotation] = pkey
-	}
-
-	netAnnotations, err := json.Marshal(pi.networks)
-	if err != nil {
-		return fmt.Errorf("failed to dump networks %+v of pod into json with error: %v", pi.networks, err)
-	}
-
-	pi.pod.Annotations[v1.NetworkAttachmentAnnot] = string(netAnnotations)
-
-	// Try to set pod's annotations in backoff loop
-	if err = wait.ExponentialBackoff(backoffValues, func() (bool, error) {
-		if err = d.kubeClient.SetAnnotationsOnPod(pi.pod, pi.pod.Annotations); err != nil {
-			if kerrors.IsNotFound(err) {
-				return false, err
-			}
-			log.Warn().Msgf("failed to update pod annotations with err: %v", err)
-			return false, nil
-		}
-
-		return true, nil
-	}); err != nil {
-		log.Error().Err(err).Msg("failed to update pod annotations")
-
-		if pi.addr != nil {
-			if relErr := d.guidPool.ReleaseGUID(pi.addr.String()); relErr != nil {
-				log.Warn().Msgf("failed to release guid \"%s\" from removed pod \"%s\" in namespace "+
-					"\"%s\" with error: %v", pi.addr.String(), pi.pod.Name, pi.pod.Namespace, relErr)
-			} else {
-				delete(d.guidPodNetworkMap, pi.addr.String())
-			}
-			*removedList = append(*removedList, pi.addr)
-		}
-
-		return fmt.Errorf("failed to set pod annotations on %s/%s: %w", pi.pod.Namespace, pi.pod.Name, err)
-	}
-
-	return nil
-}
-
-func (d *daemon) processPartitionAddIfManaged(
-	networkID string,
-	networkName string,
-	pods []*kapi.Pod,
-	netMap networksMap,
-	addMap *utils.SynchronizedMap,
-) bool {
-	if d.fabricClient == nil || !d.isPartitionManagedNAD(networkID) {
-		return false
-	}
-
-	partitionKey := d.getPartitionKeyFromNAD(networkID)
-	if partitionKey == "" {
-		ready, pkey, partErr := d.fabricClient.IsPartitionReady(networkID)
-		if partErr != nil {
-			log.Warn().Str("network_id", networkID).Err(partErr).
-				Msg("partition readiness check failed, will retry")
-			return true
-		}
-		if !ready || pkey == "" {
-			log.Debug().Str("network_id", networkID).Int("pods", len(pods)).
-				Msg("partition not ready, skipping pods")
-			return true
-		}
-		partitionKey = pkey
-		if err := d.updateNADPartitionKey(networkID, partitionKey); err != nil {
-			log.Warn().Str("network_id", networkID).Err(err).
-				Msg("failed to persist PKey to NAD")
-		}
-	}
-
-	d.processPartitionPods(pods, networkName, partitionKey, netMap, addMap, networkID)
-	return true
-}
-
-//nolint:nilerr
-func (d *daemon) AddPeriodicUpdate() {
-	log.Info().Msgf("running periodic add update")
-	addMap, _ := d.podWatcher.GetHandler().GetResults()
-	addMap.Lock()
-	defer addMap.Unlock()
-	// Contains ALL pods' networks
-	netMap := networksMap{theMap: make(map[types.UID][]*v1.NetworkSelectionElement)}
-	for networkID, podsInterface := range addMap.Items {
-		log.Info().Msgf("processing network networkID %s", networkID)
-		pods, ok := podsInterface.([]*kapi.Pod)
-		if !ok {
-			log.Error().Msgf(
-				"invalid value for add map networks expected pods array \"[]*kubernetes.Pod\", found %T",
-				podsInterface)
-			continue
-		}
-
-		if len(pods) == 0 {
-			continue
-		}
-		networkName, ibCniSpec, err := d.getIbSriovNetwork(networkID)
-		if err != nil {
-			if kerrors.IsNotFound(err) {
-				// NAD deleted (teardown) — drop from queue
-				log.Info().Str("network_id", networkID).Msg("NAD not found, dropping from add queue")
-				addMap.UnSafeRemove(networkID)
-			} else {
-				// Transient error — keep for next periodic run
-				log.Warn().Str("network_id", networkID).Err(err).Msg("NAD not ready, will retry")
-			}
-			continue
-		}
-
-		if d.processPartitionAddIfManaged(networkID, networkName, pods, netMap, addMap) {
-			continue
-		}
-
-		guidList, passedPods := d.processPodsForNetwork(pods, networkName, ibCniSpec, netMap)
-
-		// Get configured PKEY for network and add the relevant POD GUIDs as members of the PKey via Subnet Manager
-		if ibCniSpec.PKey != "" && len(guidList) != 0 {
-			var pKey int
-			pKey, err = utils.ParsePKey(ibCniSpec.PKey)
-			if err != nil {
-				log.Error().Msgf("failed to parse PKey %s with error: %v", ibCniSpec.PKey, err)
-				continue
-			}
-
-			// Try to add pKeys via subnet manager in backoff loop
-			if err = wait.ExponentialBackoff(backoffValues, func() (bool, error) {
-				if err = d.smClient.AddGuidsToPKey(pKey, guidList); err != nil {
-					log.Warn().Msgf("failed to config pKey with subnet manager %s with error : %v",
-						d.smClient.Name(), err)
-					return false, nil
-				}
-				return true, nil
-			}); err != nil {
-				log.Error().Msgf("failed to config pKey with subnet manager %s", d.smClient.Name())
-				continue
-			}
-		}
-
-		// Update annotations for PODs that finished the previous steps successfully
-		var removedGUIDList []net.HardwareAddr
-		for _, pi := range passedPods {
-			err = d.updatePodNetworkAnnotation(pi, &removedGUIDList, ibCniSpec.PKey)
-			if err != nil {
-				log.Error().Msgf("%v", err)
-			}
-		}
-
-		if ibCniSpec.PKey != "" && len(removedGUIDList) != 0 {
-			// Already check the parse above
-			pKey, _ := utils.ParsePKey(ibCniSpec.PKey)
-
-			// Try to remove pKeys via subnet manager in backoff loop
-			if err = wait.ExponentialBackoff(backoffValues, func() (bool, error) {
-				if err = d.smClient.RemoveGuidsFromPKey(pKey, removedGUIDList); err != nil {
-					log.Warn().Msgf("failed to remove guids of removed pods from pKey %s"+
-						" with subnet manager %s with error: %v", ibCniSpec.PKey,
-						d.smClient.Name(), err)
-					return false, nil
-				}
-				return true, nil
-			}); err != nil {
-				log.Warn().Msgf("failed to remove guids of removed pods from pKey %s"+
-					" with subnet manager %s", ibCniSpec.PKey, d.smClient.Name())
-				continue
-			}
-		}
-
-		addMap.UnSafeRemove(networkID)
-	}
-	log.Info().Msg("add periodic update finished")
-}
-
-// get all GUIDs and their interface-aware podNetworkIDs from Pod networks with the same name
-func getAllPodGUIDInfosForNetwork(pod *kapi.Pod, networkName string) ([]podGUIDInfo, error) {
-	networks, netErr := netAttUtils.ParsePodNetworkAnnotation(pod)
-	if netErr != nil {
-		return nil, fmt.Errorf("failed to read pod networkName annotations pod namespace %s name %s, with error: %v",
-			pod.Namespace, pod.Name, netErr)
-	}
-
-	matchingNetworks, netErr := utils.GetAllPodNetworks(networks, networkName)
-	if netErr != nil {
-		return nil, fmt.Errorf("failed to get pod networkName specs %s with error: %v", networkName, netErr)
-	}
-
-	guidInfos := make([]podGUIDInfo, 0, len(matchingNetworks))
-	for _, network := range matchingNetworks {
-		if !utils.IsPodNetworkConfiguredWithInfiniBand(network) {
-			log.Debug().Msgf("network %+v is not InfiniBand configured, skipping", network)
-			continue
-		}
-
-		allocatedGUID, netErr := utils.GetPodNetworkGUID(network)
-		if netErr != nil {
-			log.Debug().Msgf("failed to get GUID for network interface %s: %v", network.InterfaceRequest, netErr)
-			continue
-		}
-
-		guidAddr, guidErr := net.ParseMAC(allocatedGUID)
-		if guidErr != nil {
-			log.Error().Msgf("failed to parse allocated Pod GUID %s, error: %v", allocatedGUID, guidErr)
-			continue
-		}
-
-		podNetworkID := utils.GeneratePodNetworkInterfaceID(
-			pod,
-			networkName,
-			utils.GetPodNetworkInterfaceName(networks, network),
-		)
-		guidInfos = append(guidInfos, podGUIDInfo{
-			addr:         guidAddr,
-			podNetworkID: podNetworkID,
-		})
-	}
-
-	return guidInfos, nil
-}
-
-//nolint:nilerr
-func (d *daemon) DeletePeriodicUpdate() {
-	log.Info().Msg("running delete periodic update")
-	_, deleteMap := d.podWatcher.GetHandler().GetResults()
-	deleteMap.Lock()
-	defer deleteMap.Unlock()
-	for networkID, podsInterface := range deleteMap.Items {
-		log.Info().Msgf("processing network networkID %s", networkID)
-		pods, ok := podsInterface.([]*kapi.Pod)
-		if !ok {
-			log.Error().Msgf("invalid value for add map networks expected pods array \"[]*kubernetes.Pod\", found %T",
-				podsInterface)
-			continue
-		}
-
-		if len(pods) == 0 {
-			continue
-		}
-
-		networkName, ibCniSpec, err := d.getIbSriovNetwork(networkID)
-		if err != nil {
-			deleteMap.UnSafeRemove(networkID)
-			log.Warn().Msgf("droping network: %v", err)
-			continue
-		}
-
-		// Partition-managed NADs (FabricClient): use hardware GUIDs from GetNodeIBDevices.
-		// Legacy plugins (no FabricClient) fall through to the pool-allocated GUID path below.
-		if d.fabricClient != nil && d.isPartitionManagedNAD(networkID) {
-			d.deletePartitionPods(networkID, pods)
-			deleteMap.UnSafeRemove(networkID)
-			continue
-		}
-
-		var guidList []net.HardwareAddr
-		for _, pod := range pods {
-			log.Debug().Msgf("pod namespace %s name %s", pod.Namespace, pod.Name)
-
-			// Get all GUIDs and stable podNetworkIDs for all interfaces with the same network name
-			var podGUIDInfos []podGUIDInfo
-			podGUIDInfos, err = getAllPodGUIDInfosForNetwork(pod, networkName)
-			if err != nil {
-				log.Error().Msgf("%v", err)
-				continue
-			}
-
-			// Process each GUID from the pod
-			for _, podGUIDInfo := range podGUIDInfos {
-				if guidPodEntry, exist := d.guidPodNetworkMap[podGUIDInfo.addr.String()]; exist {
-					if podGUIDInfo.podNetworkID == guidPodEntry {
-						log.Info().Msgf("matched guid %s to pod %s, removing", podGUIDInfo.addr, guidPodEntry)
-						guidList = append(guidList, podGUIDInfo.addr)
-					} else {
-						log.Warn().Msgf("guid %s is allocated to another pod %s not %s, not removing",
-							podGUIDInfo.addr, guidPodEntry, podGUIDInfo.podNetworkID)
-					}
-				} else {
-					log.Warn().Msgf("guid %s is not allocated to any pod on delete", podGUIDInfo.addr)
-				}
-			}
-		}
-
-		if ibCniSpec.PKey != "" && len(guidList) != 0 {
-			pKey, pkeyErr := utils.ParsePKey(ibCniSpec.PKey)
-			if pkeyErr != nil {
-				log.Error().Msgf("failed to parse PKey %s with error: %v", ibCniSpec.PKey, pkeyErr)
-				continue
-			}
-
-			// Try to remove pKeys via subnet manager on backoff loop
-			if err = wait.ExponentialBackoff(backoffValues, func() (bool, error) {
-				if err = d.smClient.RemoveGuidsFromPKey(pKey, guidList); err != nil {
-					log.Warn().Msgf("failed to remove guids of removed pods from pKey %s"+
-						" with subnet manager %s with error: %v", ibCniSpec.PKey,
-						d.smClient.Name(), err)
-					return false, nil
-				}
-				return true, nil
-			}); err != nil {
-				log.Warn().Msgf("failed to remove guids of removed pods from pKey %s"+
-					" with subnet manager %s", ibCniSpec.PKey, d.smClient.Name())
-				continue
-			}
-		}
-
-		for _, guidAddr := range guidList {
-			if err = d.guidPool.ReleaseGUID(guidAddr.String()); err != nil {
-				log.Error().Msgf("%v", err)
-				continue
-			}
-
-			delete(d.guidPodNetworkMap, guidAddr.String())
-		}
-		deleteMap.UnSafeRemove(networkID)
-	}
-
-	log.Info().Msg("delete periodic update finished")
-}
-
-// ProcessNADChanges processes NAD add and delete events
-func (d *daemon) ProcessNADChanges() {
-	log.Debug().Msg("Processing NAD changes...")
-
-	nadHandler := d.nadWatcher.GetHandler().(*resEvenHandler.NADEventHandler)
-	addedNADs, deletedNADs := nadHandler.GetResults()
-
-	// Process NAD add events
-	addedNADs.Lock()
-	for networkID, nad := range addedNADs.Items {
-		nadObj := nad.(*v1.NetworkAttachmentDefinition)
-
-		// Cache the NAD and the parsed partition-management bit together.
-		d.cacheNAD(networkID, nadObj)
-
-		if d.fabricClient != nil {
-			if err := d.setupPartitionForNAD(nadObj); err != nil {
-				log.Warn().Msgf("Failed to setup partition for NAD %s/%s: %v (will retry)",
-					nadObj.Namespace, nadObj.Name, err)
-				continue
-			}
-		}
-
-		log.Info().Msgf("Successfully processed NAD add event: %s", networkID)
-		addedNADs.UnSafeRemove(networkID)
-	}
-	addedNADs.Unlock()
-
-	// Backfill PKey for partition-managed NADs whose partition exists but has no PKey yet.
-	if d.fabricClient != nil {
-		d.nadCache.Range(func(key, value interface{}) bool {
-			networkID := key.(string)
-			nad := value.(*v1.NetworkAttachmentDefinition)
-			if !d.isPartitionManagedNAD(networkID) {
-				return true
-			}
-			if nad.Annotations != nil && nad.Annotations[utils.PartitionKeyAnnotation] != "" {
-				return true // already has PKey, skip
-			}
-			ready, partitionKey, err := d.fabricClient.IsPartitionReady(networkID)
-			if err != nil {
-				log.Debug().Str("network_id", networkID).Err(err).
-					Msg("partition readiness check failed")
-				return true
-			}
-			if ready && partitionKey != "" {
-				log.Info().Str("network_id", networkID).Str("pkey", partitionKey).
-					Msg("partition ready, updating NAD with PKey")
-				if err := d.updateNADPartitionKey(networkID, partitionKey); err != nil {
-					log.Warn().Str("network_id", networkID).Err(err).
-						Msg("failed to update NAD partition key")
-				}
-			}
-			return true
-		})
-	}
-
-	// Process NAD delete events (partition cleanup)
-	if d.fabricClient != nil && deletedNADs != nil {
-		deletedNADs.Lock()
-		for networkID, nad := range deletedNADs.Items {
-			nadObj := nad.(*v1.NetworkAttachmentDefinition)
-			log.Info().Msgf("Processing NAD delete event: %s", networkID)
-
-			if err := d.handleNADDeletion(nadObj); err != nil {
-				log.Warn().Msgf("Failed to cleanup partition for NAD %s/%s: %v (will retry)",
-					nadObj.Namespace, nadObj.Name, err)
-				continue // Keep in queue for retry
-			}
-
-			d.deleteCachedNAD(networkID)
-			deletedNADs.UnSafeRemove(networkID)
-			log.Info().Msgf("Successfully processed NAD delete event: %s", networkID)
-		}
-		deletedNADs.Unlock()
-	}
-
-	log.Debug().Msg("NAD changes processing completed")
-}
-
-// setupPartitionForNAD creates an IB partition for a NAD with ibKubernetesEnabled
-func (d *daemon) setupPartitionForNAD(nad *v1.NetworkAttachmentDefinition) error {
-	// Skip if already has partition key annotation
-	if nad.Annotations != nil && nad.Annotations[utils.PartitionKeyAnnotation] != "" {
-		log.Debug().Msgf("NAD %s/%s already has partition-key annotation", nad.Namespace, nad.Name)
-		return nil
-	}
-
-	networkSpec := make(map[string]interface{})
-	if err := json.Unmarshal([]byte(nad.Spec.Config), &networkSpec); err != nil {
-		return fmt.Errorf("failed to parse NAD spec: %v", err)
-	}
-
-	if !utils.IsIbSriovCniSpec(networkSpec) {
-		log.Debug().Msgf("NAD %s/%s is not an ib-sriov network, skipping partition setup", nad.Namespace, nad.Name)
-		return nil
-	}
-
-	if enabled, ok := networkSpec[utils.IBKubernetesEnabled]; !ok || enabled != true {
-		log.Debug().Msgf("NAD %s/%s does not have ibKubernetesEnabled, skipping", nad.Namespace, nad.Name)
-		return nil
-	}
-
-	// Create partition: name = namespace_nadName (deterministic from NAD)
-	partitionName := fmt.Sprintf("%s_%s", nad.Namespace, nad.Name)
-	log.Info().Msgf("Creating IB partition for NAD %s/%s with name: %s", nad.Namespace, nad.Name, partitionName)
-
-	partitionKey, err := d.fabricClient.CreateIBPartition(partitionName)
-	if err != nil {
-		return fmt.Errorf("failed to create IB partition: %v", err)
-	}
-
-	log.Info().Msgf("Created IB partition '%s' with PKey: %s for NAD %s/%s",
-		partitionName, partitionKey, nad.Namespace, nad.Name)
-
-	// Annotate NAD with PKey and add finalizer
-	if partitionKey != "" {
-		return d.updateNADPartitionKey(partitionName, partitionKey)
-	}
-
-	// PKey not yet assigned (partition not ready) — add finalizer only
-	return d.addNADFinalizer(nad)
-}
-
-// addNADFinalizer adds the partition finalizer to a NAD
-func (d *daemon) addNADFinalizer(nad *v1.NetworkAttachmentDefinition) error {
-	return wait.ExponentialBackoff(backoffValues, func() (bool, error) {
-		freshNAD, err := d.kubeClient.GetNetworkAttachmentDefinition(nad.Namespace, nad.Name)
-		if err != nil {
-			return false, fmt.Errorf("failed to fetch fresh NAD: %v", err)
-		}
-
-		if hasNADFinalizer(freshNAD, utils.PartitionNADFinalizer) {
-			return true, nil
-		}
-
-		freshNAD.Finalizers = append(freshNAD.Finalizers, utils.PartitionNADFinalizer)
-		if err := d.kubeClient.UpdateNetworkAttachmentDefinition(freshNAD); err != nil {
-			if kerrors.IsConflict(err) {
-				return false, nil
-			}
-			return false, fmt.Errorf("failed to add finalizer to NAD: %v", err)
-		}
-
-		networkID := fmt.Sprintf("%s_%s", freshNAD.Namespace, freshNAD.Name)
-		d.cacheNAD(networkID, freshNAD)
-		return true, nil
-	})
-}
-
-// updateNADPartitionKey annotates NAD with partition key and adds finalizer
-func (d *daemon) updateNADPartitionKey(networkID, partitionKey string) error {
-	networkNamespace, networkName, err := utils.ParseNetworkID(networkID)
-	if err != nil {
-		return fmt.Errorf("failed to parse network id %s: %v", networkID, err)
-	}
-
-	return wait.ExponentialBackoff(backoffValues, func() (bool, error) {
-		freshNAD, err := d.kubeClient.GetNetworkAttachmentDefinition(networkNamespace, networkName)
-		if err != nil {
-			return false, fmt.Errorf("failed to fetch fresh NAD: %v", err)
-		}
-
-		if freshNAD.Annotations == nil {
-			freshNAD.Annotations = make(map[string]string)
-		}
-
-		freshNAD.Annotations[utils.PartitionKeyAnnotation] = partitionKey
-
-		if !hasNADFinalizer(freshNAD, utils.PartitionNADFinalizer) {
-			freshNAD.Finalizers = append(freshNAD.Finalizers, utils.PartitionNADFinalizer)
-		}
-
-		if err := d.kubeClient.UpdateNetworkAttachmentDefinition(freshNAD); err != nil {
-			if kerrors.IsConflict(err) {
-				return false, nil
-			}
-			return false, fmt.Errorf("failed to update NAD: %v", err)
-		}
-
-		log.Info().Msgf("Updated NAD %s/%s with partition-key: %s",
-			freshNAD.Namespace, freshNAD.Name, partitionKey)
-
-		d.cacheNAD(networkID, freshNAD)
-		return true, nil
-	})
-}
-
-// handleNADDeletion cleans up partition when NAD enters Terminating state.
-// The NAD still exists with its annotations — we clean up the backend partition,
-// then remove the finalizer so K8s can complete the deletion.
-func (d *daemon) handleNADDeletion(nad *v1.NetworkAttachmentDefinition) error {
-	partitionName := fmt.Sprintf("%s_%s", nad.Namespace, nad.Name)
-	log.Info().Msgf("Deleting IB partition '%s' for NAD %s/%s", partitionName, nad.Namespace, nad.Name)
-
-	if err := d.fabricClient.DeleteIBPartition(partitionName); err != nil {
-		return fmt.Errorf("failed to delete partition '%s': %v", partitionName, err)
-	}
-
-	log.Info().Msgf("Successfully deleted IB partition '%s'", partitionName)
-
-	// Remove finalizer so K8s can complete NAD deletion
-	return d.removeNADFinalizer(nad, utils.PartitionNADFinalizer)
-}
-
-// removeNADFinalizer removes a specific finalizer from a NAD.
-// Retries on conflict (409) to prevent stuck NADs in Terminating state.
-func (d *daemon) removeNADFinalizer(nad *v1.NetworkAttachmentDefinition, finalizer string) error {
-	return wait.ExponentialBackoff(backoffValues, func() (bool, error) {
-		freshNAD, err := d.kubeClient.GetNetworkAttachmentDefinition(nad.Namespace, nad.Name)
-		if err != nil {
-			if kerrors.IsNotFound(err) {
-				return true, nil // NAD already deleted
-			}
-			return false, fmt.Errorf("failed to fetch fresh NAD: %v", err)
-		}
-
-		newFinalizers := make([]string, 0, len(freshNAD.Finalizers))
-		for _, f := range freshNAD.Finalizers {
-			if f != finalizer {
-				newFinalizers = append(newFinalizers, f)
-			}
-		}
-
-		if len(newFinalizers) == len(freshNAD.Finalizers) {
-			return true, nil // finalizer not present
-		}
-
-		freshNAD.Finalizers = newFinalizers
-		if err := d.kubeClient.UpdateNetworkAttachmentDefinition(freshNAD); err != nil {
-			if kerrors.IsConflict(err) {
-				return false, nil
-			}
-			return false, fmt.Errorf("failed to remove finalizer from NAD: %v", err)
-		}
-
-		log.Info().Msgf("Removed finalizer %s from NAD %s/%s", finalizer, nad.Namespace, nad.Name)
-		return true, nil
-	})
-}
-
-// hasNADFinalizer checks if a NAD has a specific finalizer
-func hasNADFinalizer(nad *v1.NetworkAttachmentDefinition, finalizer string) bool {
-	for _, f := range nad.Finalizers {
-		if f == finalizer {
-			return true
-		}
-	}
-	return false
-}
-
-// processPartitionPods handles pod processing for partition-aware plugins.
-// Uses hardware PF GUIDs from GetNodeIBDevices instead of pool-allocated GUIDs.
-// Handles ErrPending from AddGuidsToPKey for non-blocking backend provisioning.
-func (d *daemon) processPartitionPods(
-	pods []*kapi.Pod,
-	networkName string,
-	partitionKey string,
-	netMap networksMap,
-	addMap *utils.SynchronizedMap,
-	networkID string,
-) {
-	if d.fabricClient == nil {
-		log.Debug().Str("network_id", networkID).Msg("fabric client unavailable, skipping partition add")
-		return
-	}
-
-	pKey, err := utils.ParsePKey(partitionKey)
-	if err != nil {
-		log.Error().Msgf("failed to parse partition key %s: %v", partitionKey, err)
-		return
-	}
-
-	allProcessed := true
-	for _, pod := range pods {
-		// Get hardware GUIDs for this pod's node
-		devices, devErr := d.fabricClient.GetNodeIBDevices(pod.Spec.NodeName)
-		if devErr != nil {
-			log.Error().Str("node", pod.Spec.NodeName).Err(devErr).
-				Msg("failed to get IB devices for node")
-			allProcessed = false
-			continue
-		}
-
-		// Collect all PF GUIDs for this node
-		guids := make([]net.HardwareAddr, 0, len(devices))
-		for _, dev := range devices {
-			guids = append(guids, dev.GUID)
-		}
-
-		if len(guids) == 0 {
-			log.Warn().Str("node", pod.Spec.NodeName).
-				Str("pod", pod.Name).Str("namespace", pod.Namespace).
-				Msg("no IB devices found on node")
-			allProcessed = false
-			continue
-		}
-
-		// Call AddGuidsToPKey — may return ErrPending
-		addErr := d.smClient.AddGuidsToPKey(pKey, guids)
-		if addErr != nil {
-			if errors.Is(addErr, plugins.ErrPending) {
-				log.Debug().Str("pod", pod.Name).Str("namespace", pod.Namespace).
-					Str("node", pod.Spec.NodeName).Int("interfaces", len(guids)).
-					Msg("backend provisioning pending")
-				allProcessed = false
-				continue
-			}
-			log.Error().Str("pod", pod.Name).Str("namespace", pod.Namespace).
-				Err(addErr).Msg("AddGuidsToPKey failed")
-			allProcessed = false
-			continue
-		}
-
-		// Success — annotate pod (log once per pod, not per interface)
-		podNetworkInfos, piErr := getAllPodNetworkInfos(networkName, pod, netMap)
-		if piErr != nil {
-			log.Error().Err(piErr).Msg("failed to get pod network infos")
-			allProcessed = false
-			continue
-		}
-
-		log.Info().Str("pod", pod.Name).Str("namespace", pod.Namespace).
-			Str("node", pod.Spec.NodeName).Str("network", networkName).
-			Str("pkey", partitionKey).Int("interfaces", len(podNetworkInfos)).
-			Msg("IB ready, annotating pod")
-
-		// PF mode: only set mellanox.infiniband.app=configured (no pkey in cni-args).
-		// pi.addr is unset, so the removedGUIDList sink stays empty.
-		var removedGUIDList []net.HardwareAddr
-		for _, pi := range podNetworkInfos {
-			if updateErr := d.updatePodNetworkAnnotation(pi, &removedGUIDList, ""); updateErr != nil {
-				log.Error().Err(updateErr).Msg("failed to update pod annotation")
-				allProcessed = false
-			}
-		}
-	}
-
-	if allProcessed {
-		addMap.UnSafeRemove(networkID)
-	}
-}
-
-// getCachedNAD retrieves NAD from cache, falling back to API if not cached
-func (d *daemon) getCachedNAD(networkID string) (*v1.NetworkAttachmentDefinition, error) {
-	// First check cache
-	if val, exists := d.nadCache.Load(networkID); exists {
-		return val.(*v1.NetworkAttachmentDefinition), nil
-	}
-
-	// Fall back to API call (existing behavior)
-	networkNamespace, networkName, err := utils.ParseNetworkID(networkID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse network id %s with error: %v", networkID, err)
-	}
-
-	var netAttInfo *v1.NetworkAttachmentDefinition
-	if err = wait.ExponentialBackoff(backoffValues, func() (bool, error) {
-		var getErr error
-		netAttInfo, getErr = d.kubeClient.GetNetworkAttachmentDefinition(networkNamespace, networkName)
-		if getErr != nil {
-			if kerrors.IsNotFound(getErr) {
-				// NAD deleted (teardown) — stop retrying
-				return false, getErr
-			}
-			log.Warn().Str("namespace", networkNamespace).Str("name", networkName).Err(getErr).
-				Msg("failed to get network attachment, retrying")
-			return false, nil
-		}
-		return true, nil
-	}); err != nil {
-		return nil, fmt.Errorf("failed to get network attachment %s/%s: %w", networkNamespace, networkName, err)
-	}
-
-	// Cache the result
-	d.cacheNAD(networkID, netAttInfo)
-
-	return netAttInfo, nil
-}
-
-// initGUIDPool initializes the GUID pool by first populating guidPodNetworkMap with existing pods,
-// then syncing with subnet manager and cleaning up stale GUIDs
-func (d *daemon) initGUIDPool() error {
-	log.Info().Msg("Initializing GUID pool.")
-
-	// First populate guidPodNetworkMap with existing pods
-	var pods *kapi.PodList
-	if err := wait.ExponentialBackoff(backoffValues, func() (bool, error) {
-		var err error
-		if pods, err = d.kubeClient.GetPods(kapi.NamespaceAll); err != nil {
-			log.Warn().Msgf("failed to get pods from kubernetes: %v", err)
-			return false, nil
-		}
-		return true, nil
-	}); err != nil {
-		err = fmt.Errorf("failed to get pods from kubernetes")
-		log.Error().Msgf("%v", err)
-		return err
-	}
-
-	for index := range pods.Items {
-		log.Debug().Msgf("checking pod for network annotations %v", pods.Items[index])
-		pod := pods.Items[index]
-		if utils.PodIsFinished(&pod) {
-			continue
-		}
-		networks, err := netAttUtils.ParsePodNetworkAnnotation(&pod)
-		if err != nil {
-			continue
-		}
-
-		for _, network := range networks {
-			if !utils.IsPodNetworkConfiguredWithInfiniBand(network) {
-				continue
-			}
-
-			podGUID, err := utils.GetPodNetworkGUID(network)
-			if err != nil {
-				continue
-			}
-
-			podNetworkID := utils.GeneratePodNetworkInterfaceID(
-				&pod,
-				network.Name,
-				utils.GetPodNetworkInterfaceName(networks, network),
-			)
-			if _, exist := d.guidPodNetworkMap[podGUID]; exist {
-				if podNetworkID != d.guidPodNetworkMap[podGUID] {
-					return fmt.Errorf("failed to allocate requested guid %s, already allocated for %s",
-						podGUID, d.guidPodNetworkMap[podGUID])
-				}
-				continue
-			}
-			podPkey, _ := utils.GetPodNetworkPkey(network)
-			if err = d.guidPool.AllocateGUID(podGUID, podPkey); err != nil {
-				err = fmt.Errorf("failed to allocate guid for running pod: %v", err)
-				log.Error().Msgf("%v", err)
-				continue
-			}
-
-			d.guidPodNetworkMap[podGUID] = podNetworkID
-		}
-	}
-
-	// Now sync with subnet manager and clean up stale GUIDs
-	return d.syncWithSubnetManager()
-}
-
-// syncWithSubnetManager syncs the GUID pool with the subnet manager
-// This is used both during initialization and when the pool is exhausted at runtime
-func (d *daemon) syncWithSubnetManager() error {
-	usedGuids, err := d.smClient.ListGuidsInUse()
-	if err != nil {
-		return err
-	}
-
-	// Reset guid pool with already allocated guids to avoid collisions
-	err = d.guidPool.Reset(usedGuids)
-	if err != nil {
-		return err
-	}
-
-	// Remove stale GUIDs that are no longer in use by the subnet manager
-	// This handles cleanup of GUIDs from deleted/finished pods
-	for allocatedGUID, podNetworkID := range d.guidPodNetworkMap {
-		if _, found := usedGuids[allocatedGUID]; !found {
-			// If GUID is not found in the subnet manager's list of used GUIDs,
-			// it means the pod was deleted/finished and we should clean it up
-			log.Info().Msgf("removing stale GUID %s for pod network %s", allocatedGUID, podNetworkID)
-			if err = d.guidPool.ReleaseGUID(allocatedGUID); err != nil {
-				log.Warn().Msgf("failed to release stale guid \"%s\" with error: %v", allocatedGUID, err)
-			} else {
-				delete(d.guidPodNetworkMap, allocatedGUID)
-				log.Info().Msgf("successfully cleaned up stale GUID %s", allocatedGUID)
-			}
-		}
-	}
-
-	return nil
 }

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -19,11 +19,13 @@ package daemon
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"os"
 	"os/signal"
 	"path"
+	"sync"
 	"syscall"
 	"time"
 
@@ -60,10 +62,12 @@ type daemon struct {
 	kubeClient        k8sClient.Client
 	guidPool          guid.Pool
 	smClient          plugins.SubnetManagerClient
-	guidPodNetworkMap map[string]string // allocated guid mapped to the pod and network
+	fabricClient      plugins.FabricClient // nil if plugin does not implement FabricClient
+	guidPodNetworkMap map[string]string    // allocated guid mapped to the pod and network
 
-	// NAD add-only cache
-	nadCache map[string]*v1.NetworkAttachmentDefinition // network ID -> NAD
+	// NAD caches — sync.Map for concurrent access from AddPeriodicUpdate + ProcessNADChanges goroutines.
+	nadCache              sync.Map // network ID (string) -> *v1.NetworkAttachmentDefinition
+	partitionManagedCache sync.Map // network ID (string) -> bool
 }
 
 // Temporary struct used to proceed pods' networks
@@ -136,6 +140,13 @@ func NewDaemon() (Daemon, error) {
 		return nil, err
 	}
 
+	// Check if plugin implements FabricClient (optional interface for partition-aware plugins)
+	var fabricClient plugins.FabricClient
+	if pc, ok := smClient.(plugins.FabricClient); ok {
+		fabricClient = pc
+		log.Info().Msgf("Plugin %s implements FabricClient interface", smClient.Name())
+	}
+
 	// Try to validate if subnet manager is reachable in backoff loop
 	var validateErr error
 	if err := wait.ExponentialBackoff(backoffValues, func() (bool, error) {
@@ -163,10 +174,10 @@ func NewDaemon() (Daemon, error) {
 		kubeClient:        client,
 		guidPool:          guidPool,
 		smClient:          smClient,
+		fabricClient:      fabricClient,
 		guidPodNetworkMap: make(map[string]string),
 		podWatcher:        podWatcher,
 		nadWatcher:        nadWatcher,
-		nadCache:          make(map[string]*v1.NetworkAttachmentDefinition),
 	}, nil
 }
 
@@ -324,7 +335,7 @@ func (d *daemon) getIbSriovNetwork(networkID string) (string, *utils.IbSriovCniS
 	// Try to get net-attach-def from cache first, then fallback to API
 	netAttInfo, err := d.getCachedNAD(networkID)
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to get network attachment %s: %v", networkName, err)
+		return "", nil, fmt.Errorf("failed to get network attachment %s: %w", networkName, err)
 	}
 	log.Debug().Msgf("networkName attachment %v", netAttInfo)
 
@@ -344,6 +355,100 @@ func (d *daemon) getIbSriovNetwork(networkID string) (string, *utils.IbSriovCniS
 
 	log.Debug().Msgf("ib-sriov CNI spec %+v", ibCniSpec)
 	return networkName, ibCniSpec, nil
+}
+
+// getPartitionKeyFromNAD reads the partition PKey from NAD annotation (set by partition-aware plugins)
+func (d *daemon) getPartitionKeyFromNAD(networkID string) string {
+	if val, exists := d.nadCache.Load(networkID); exists {
+		nad := val.(*v1.NetworkAttachmentDefinition)
+		if nad.Annotations != nil {
+			return nad.Annotations[utils.PartitionKeyAnnotation]
+		}
+	}
+	return ""
+}
+
+func (d *daemon) cacheNAD(networkID string, nad *v1.NetworkAttachmentDefinition) {
+	d.nadCache.Store(networkID, nad)
+	d.partitionManagedCache.Store(networkID, isPartitionManagedConfig(networkID, nad.Spec.Config))
+}
+
+func (d *daemon) deleteCachedNAD(networkID string) {
+	d.nadCache.Delete(networkID)
+	d.partitionManagedCache.Delete(networkID)
+}
+
+// isPartitionManagedNAD checks if a NAD has ibKubernetesEnabled set to true,
+// meaning it should be managed via the partition-aware (FabricClient) path.
+func (d *daemon) isPartitionManagedNAD(networkID string) bool {
+	if val, exists := d.partitionManagedCache.Load(networkID); exists {
+		enabled, ok := val.(bool)
+		return ok && enabled
+	}
+
+	val, exists := d.nadCache.Load(networkID)
+	if !exists {
+		return false
+	}
+	nad := val.(*v1.NetworkAttachmentDefinition)
+
+	enabled := isPartitionManagedConfig(networkID, nad.Spec.Config)
+	d.partitionManagedCache.Store(networkID, enabled)
+	return enabled
+}
+
+func isPartitionManagedConfig(networkID, config string) bool {
+	networkSpec := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(config), &networkSpec); err != nil {
+		log.Warn().Str("network_id", networkID).Err(err).Msg("isPartitionManagedNAD: failed to parse NAD config")
+		return false
+	}
+	enabled, ok := networkSpec[utils.IBKubernetesEnabled].(bool)
+	return ok && enabled
+}
+
+// deletePartitionPods removes a node's PF GUIDs from the partition for each deleted pod.
+// Assumes single-pod-per-node-per-partition (fat-VM); a per-(networkID,nodeName) refcount
+// over live pods would be needed before lifting that.
+func (d *daemon) deletePartitionPods(networkID string, pods []*kapi.Pod) {
+	if d.fabricClient == nil {
+		log.Debug().Str("network_id", networkID).Msg("fabric client unavailable, skipping partition delete")
+		return
+	}
+
+	partitionKey := d.getPartitionKeyFromNAD(networkID)
+	if partitionKey == "" {
+		log.Debug().Str("network_id", networkID).Msg("no partition key on NAD, skipping delete")
+		return
+	}
+	pKey, pkeyErr := utils.ParsePKey(partitionKey)
+	if pkeyErr != nil {
+		log.Error().Str("network_id", networkID).Err(pkeyErr).Msg("failed to parse partition key")
+		return
+	}
+
+	for _, pod := range pods {
+		devices, devErr := d.fabricClient.GetNodeIBDevices(pod.Spec.NodeName)
+		if devErr != nil {
+			log.Error().Str("node", pod.Spec.NodeName).Err(devErr).
+				Msg("failed to get IB devices for node on delete")
+			continue
+		}
+		guids := make([]net.HardwareAddr, 0, len(devices))
+		for _, dev := range devices {
+			guids = append(guids, dev.GUID)
+		}
+		if len(guids) > 0 {
+			if rmErr := d.smClient.RemoveGuidsFromPKey(pKey, guids); rmErr != nil {
+				log.Warn().Str("pod", pod.Name).Str("node", pod.Spec.NodeName).
+					Err(rmErr).Msg("failed to remove GUIDs from partition on delete")
+			} else {
+				log.Info().Str("pod", pod.Name).Str("node", pod.Spec.NodeName).
+					Str("pkey", partitionKey).Int("guids", len(guids)).
+					Msg("removed node GUIDs from partition")
+			}
+		}
+	}
 }
 
 // Return pod network info
@@ -534,7 +639,9 @@ func (d *daemon) updatePodNetworkAnnotation(pi *podNetworkInfo, removedList *[]n
 	}
 
 	(*pi.ibNetwork.CNIArgs)[utils.InfiniBandAnnotation] = utils.ConfiguredInfiniBandPod
-	(*pi.ibNetwork.CNIArgs)[utils.PkeyAnnotation] = pkey
+	if pkey != "" {
+		(*pi.ibNetwork.CNIArgs)[utils.PkeyAnnotation] = pkey
+	}
 
 	netAnnotations, err := json.Marshal(pi.networks)
 	if err != nil {
@@ -555,19 +662,57 @@ func (d *daemon) updatePodNetworkAnnotation(pi *podNetworkInfo, removedList *[]n
 
 		return true, nil
 	}); err != nil {
-		log.Error().Msgf("failed to update pod annotations")
+		log.Error().Err(err).Msg("failed to update pod annotations")
 
-		if err = d.guidPool.ReleaseGUID(pi.addr.String()); err != nil {
-			log.Warn().Msgf("failed to release guid \"%s\" from removed pod \"%s\" in namespace "+
-				"\"%s\" with error: %v", pi.addr.String(), pi.pod.Name, pi.pod.Namespace, err)
-		} else {
-			delete(d.guidPodNetworkMap, pi.addr.String())
+		if pi.addr != nil {
+			if relErr := d.guidPool.ReleaseGUID(pi.addr.String()); relErr != nil {
+				log.Warn().Msgf("failed to release guid \"%s\" from removed pod \"%s\" in namespace "+
+					"\"%s\" with error: %v", pi.addr.String(), pi.pod.Name, pi.pod.Namespace, relErr)
+			} else {
+				delete(d.guidPodNetworkMap, pi.addr.String())
+			}
+			*removedList = append(*removedList, pi.addr)
 		}
 
-		*removedList = append(*removedList, pi.addr)
+		return fmt.Errorf("failed to set pod annotations on %s/%s: %w", pi.pod.Namespace, pi.pod.Name, err)
 	}
 
 	return nil
+}
+
+func (d *daemon) processPartitionAddIfManaged(
+	networkID string,
+	networkName string,
+	pods []*kapi.Pod,
+	netMap networksMap,
+	addMap *utils.SynchronizedMap,
+) bool {
+	if d.fabricClient == nil || !d.isPartitionManagedNAD(networkID) {
+		return false
+	}
+
+	partitionKey := d.getPartitionKeyFromNAD(networkID)
+	if partitionKey == "" {
+		ready, pkey, partErr := d.fabricClient.IsPartitionReady(networkID)
+		if partErr != nil {
+			log.Warn().Str("network_id", networkID).Err(partErr).
+				Msg("partition readiness check failed, will retry")
+			return true
+		}
+		if !ready || pkey == "" {
+			log.Debug().Str("network_id", networkID).Int("pods", len(pods)).
+				Msg("partition not ready, skipping pods")
+			return true
+		}
+		partitionKey = pkey
+		if err := d.updateNADPartitionKey(networkID, partitionKey); err != nil {
+			log.Warn().Str("network_id", networkID).Err(err).
+				Msg("failed to persist PKey to NAD")
+		}
+	}
+
+	d.processPartitionPods(pods, networkName, partitionKey, netMap, addMap, networkID)
+	return true
 }
 
 //nolint:nilerr
@@ -593,8 +738,18 @@ func (d *daemon) AddPeriodicUpdate() {
 		}
 		networkName, ibCniSpec, err := d.getIbSriovNetwork(networkID)
 		if err != nil {
-			// Do not drop the network; keep for next periodic run when NAD becomes available
-			log.Warn().Msgf("NAD not ready for network %s: %v (will retry)", networkID, err)
+			if kerrors.IsNotFound(err) {
+				// NAD deleted (teardown) — drop from queue
+				log.Info().Str("network_id", networkID).Msg("NAD not found, dropping from add queue")
+				addMap.UnSafeRemove(networkID)
+			} else {
+				// Transient error — keep for next periodic run
+				log.Warn().Str("network_id", networkID).Err(err).Msg("NAD not ready, will retry")
+			}
+			continue
+		}
+
+		if d.processPartitionAddIfManaged(networkID, networkName, pods, netMap, addMap) {
 			continue
 		}
 
@@ -729,6 +884,14 @@ func (d *daemon) DeletePeriodicUpdate() {
 			continue
 		}
 
+		// Partition-managed NADs (FabricClient): use hardware GUIDs from GetNodeIBDevices.
+		// Legacy plugins (no FabricClient) fall through to the pool-allocated GUID path below.
+		if d.fabricClient != nil && d.isPartitionManagedNAD(networkID) {
+			d.deletePartitionPods(networkID, pods)
+			deleteMap.UnSafeRemove(networkID)
+			continue
+		}
+
 		var guidList []net.HardwareAddr
 		for _, pod := range pods {
 			log.Debug().Msgf("pod namespace %s name %s", pod.Namespace, pod.Name)
@@ -794,36 +957,354 @@ func (d *daemon) DeletePeriodicUpdate() {
 	log.Info().Msg("delete periodic update finished")
 }
 
-// ProcessNADChanges processes NAD add events
+// ProcessNADChanges processes NAD add and delete events
 func (d *daemon) ProcessNADChanges() {
 	log.Debug().Msg("Processing NAD changes...")
 
 	nadHandler := d.nadWatcher.GetHandler().(*resEvenHandler.NADEventHandler)
-	addedNADs, _ := nadHandler.GetResults()
+	addedNADs, deletedNADs := nadHandler.GetResults()
 
-	// Process NAD add events only
+	// Process NAD add events
 	addedNADs.Lock()
 	for networkID, nad := range addedNADs.Items {
 		nadObj := nad.(*v1.NetworkAttachmentDefinition)
 
-		// Add-only: cache the NAD; ignore updates/deletes
-		d.nadCache[networkID] = nadObj
+		// Cache the NAD and the parsed partition-management bit together.
+		d.cacheNAD(networkID, nadObj)
 
-		log.Info().Msgf("Successfully processed NAD event: %s", networkID)
+		if d.fabricClient != nil {
+			if err := d.setupPartitionForNAD(nadObj); err != nil {
+				log.Warn().Msgf("Failed to setup partition for NAD %s/%s: %v (will retry)",
+					nadObj.Namespace, nadObj.Name, err)
+				continue
+			}
+		}
 
-		// Remove processed item
+		log.Info().Msgf("Successfully processed NAD add event: %s", networkID)
 		addedNADs.UnSafeRemove(networkID)
 	}
 	addedNADs.Unlock()
 
+	// Backfill PKey for partition-managed NADs whose partition exists but has no PKey yet.
+	if d.fabricClient != nil {
+		d.nadCache.Range(func(key, value interface{}) bool {
+			networkID := key.(string)
+			nad := value.(*v1.NetworkAttachmentDefinition)
+			if !d.isPartitionManagedNAD(networkID) {
+				return true
+			}
+			if nad.Annotations != nil && nad.Annotations[utils.PartitionKeyAnnotation] != "" {
+				return true // already has PKey, skip
+			}
+			ready, partitionKey, err := d.fabricClient.IsPartitionReady(networkID)
+			if err != nil {
+				log.Debug().Str("network_id", networkID).Err(err).
+					Msg("partition readiness check failed")
+				return true
+			}
+			if ready && partitionKey != "" {
+				log.Info().Str("network_id", networkID).Str("pkey", partitionKey).
+					Msg("partition ready, updating NAD with PKey")
+				if err := d.updateNADPartitionKey(networkID, partitionKey); err != nil {
+					log.Warn().Str("network_id", networkID).Err(err).
+						Msg("failed to update NAD partition key")
+				}
+			}
+			return true
+		})
+	}
+
+	// Process NAD delete events (partition cleanup)
+	if d.fabricClient != nil && deletedNADs != nil {
+		deletedNADs.Lock()
+		for networkID, nad := range deletedNADs.Items {
+			nadObj := nad.(*v1.NetworkAttachmentDefinition)
+			log.Info().Msgf("Processing NAD delete event: %s", networkID)
+
+			if err := d.handleNADDeletion(nadObj); err != nil {
+				log.Warn().Msgf("Failed to cleanup partition for NAD %s/%s: %v (will retry)",
+					nadObj.Namespace, nadObj.Name, err)
+				continue // Keep in queue for retry
+			}
+
+			d.deleteCachedNAD(networkID)
+			deletedNADs.UnSafeRemove(networkID)
+			log.Info().Msgf("Successfully processed NAD delete event: %s", networkID)
+		}
+		deletedNADs.Unlock()
+	}
+
 	log.Debug().Msg("NAD changes processing completed")
+}
+
+// setupPartitionForNAD creates an IB partition for a NAD with ibKubernetesEnabled
+func (d *daemon) setupPartitionForNAD(nad *v1.NetworkAttachmentDefinition) error {
+	// Skip if already has partition key annotation
+	if nad.Annotations != nil && nad.Annotations[utils.PartitionKeyAnnotation] != "" {
+		log.Debug().Msgf("NAD %s/%s already has partition-key annotation", nad.Namespace, nad.Name)
+		return nil
+	}
+
+	networkSpec := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(nad.Spec.Config), &networkSpec); err != nil {
+		return fmt.Errorf("failed to parse NAD spec: %v", err)
+	}
+
+	if !utils.IsIbSriovCniSpec(networkSpec) {
+		log.Debug().Msgf("NAD %s/%s is not an ib-sriov network, skipping partition setup", nad.Namespace, nad.Name)
+		return nil
+	}
+
+	if enabled, ok := networkSpec[utils.IBKubernetesEnabled]; !ok || enabled != true {
+		log.Debug().Msgf("NAD %s/%s does not have ibKubernetesEnabled, skipping", nad.Namespace, nad.Name)
+		return nil
+	}
+
+	// Create partition: name = namespace_nadName (deterministic from NAD)
+	partitionName := fmt.Sprintf("%s_%s", nad.Namespace, nad.Name)
+	log.Info().Msgf("Creating IB partition for NAD %s/%s with name: %s", nad.Namespace, nad.Name, partitionName)
+
+	partitionKey, err := d.fabricClient.CreateIBPartition(partitionName)
+	if err != nil {
+		return fmt.Errorf("failed to create IB partition: %v", err)
+	}
+
+	log.Info().Msgf("Created IB partition '%s' with PKey: %s for NAD %s/%s",
+		partitionName, partitionKey, nad.Namespace, nad.Name)
+
+	// Annotate NAD with PKey and add finalizer
+	if partitionKey != "" {
+		return d.updateNADPartitionKey(partitionName, partitionKey)
+	}
+
+	// PKey not yet assigned (partition not ready) — add finalizer only
+	return d.addNADFinalizer(nad)
+}
+
+// addNADFinalizer adds the partition finalizer to a NAD
+func (d *daemon) addNADFinalizer(nad *v1.NetworkAttachmentDefinition) error {
+	return wait.ExponentialBackoff(backoffValues, func() (bool, error) {
+		freshNAD, err := d.kubeClient.GetNetworkAttachmentDefinition(nad.Namespace, nad.Name)
+		if err != nil {
+			return false, fmt.Errorf("failed to fetch fresh NAD: %v", err)
+		}
+
+		if hasNADFinalizer(freshNAD, utils.PartitionNADFinalizer) {
+			return true, nil
+		}
+
+		freshNAD.Finalizers = append(freshNAD.Finalizers, utils.PartitionNADFinalizer)
+		if err := d.kubeClient.UpdateNetworkAttachmentDefinition(freshNAD); err != nil {
+			if kerrors.IsConflict(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("failed to add finalizer to NAD: %v", err)
+		}
+
+		networkID := fmt.Sprintf("%s_%s", freshNAD.Namespace, freshNAD.Name)
+		d.cacheNAD(networkID, freshNAD)
+		return true, nil
+	})
+}
+
+// updateNADPartitionKey annotates NAD with partition key and adds finalizer
+func (d *daemon) updateNADPartitionKey(networkID, partitionKey string) error {
+	networkNamespace, networkName, err := utils.ParseNetworkID(networkID)
+	if err != nil {
+		return fmt.Errorf("failed to parse network id %s: %v", networkID, err)
+	}
+
+	return wait.ExponentialBackoff(backoffValues, func() (bool, error) {
+		freshNAD, err := d.kubeClient.GetNetworkAttachmentDefinition(networkNamespace, networkName)
+		if err != nil {
+			return false, fmt.Errorf("failed to fetch fresh NAD: %v", err)
+		}
+
+		if freshNAD.Annotations == nil {
+			freshNAD.Annotations = make(map[string]string)
+		}
+
+		freshNAD.Annotations[utils.PartitionKeyAnnotation] = partitionKey
+
+		if !hasNADFinalizer(freshNAD, utils.PartitionNADFinalizer) {
+			freshNAD.Finalizers = append(freshNAD.Finalizers, utils.PartitionNADFinalizer)
+		}
+
+		if err := d.kubeClient.UpdateNetworkAttachmentDefinition(freshNAD); err != nil {
+			if kerrors.IsConflict(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("failed to update NAD: %v", err)
+		}
+
+		log.Info().Msgf("Updated NAD %s/%s with partition-key: %s",
+			freshNAD.Namespace, freshNAD.Name, partitionKey)
+
+		d.cacheNAD(networkID, freshNAD)
+		return true, nil
+	})
+}
+
+// handleNADDeletion cleans up partition when NAD enters Terminating state.
+// The NAD still exists with its annotations — we clean up the backend partition,
+// then remove the finalizer so K8s can complete the deletion.
+func (d *daemon) handleNADDeletion(nad *v1.NetworkAttachmentDefinition) error {
+	partitionName := fmt.Sprintf("%s_%s", nad.Namespace, nad.Name)
+	log.Info().Msgf("Deleting IB partition '%s' for NAD %s/%s", partitionName, nad.Namespace, nad.Name)
+
+	if err := d.fabricClient.DeleteIBPartition(partitionName); err != nil {
+		return fmt.Errorf("failed to delete partition '%s': %v", partitionName, err)
+	}
+
+	log.Info().Msgf("Successfully deleted IB partition '%s'", partitionName)
+
+	// Remove finalizer so K8s can complete NAD deletion
+	return d.removeNADFinalizer(nad, utils.PartitionNADFinalizer)
+}
+
+// removeNADFinalizer removes a specific finalizer from a NAD.
+// Retries on conflict (409) to prevent stuck NADs in Terminating state.
+func (d *daemon) removeNADFinalizer(nad *v1.NetworkAttachmentDefinition, finalizer string) error {
+	return wait.ExponentialBackoff(backoffValues, func() (bool, error) {
+		freshNAD, err := d.kubeClient.GetNetworkAttachmentDefinition(nad.Namespace, nad.Name)
+		if err != nil {
+			if kerrors.IsNotFound(err) {
+				return true, nil // NAD already deleted
+			}
+			return false, fmt.Errorf("failed to fetch fresh NAD: %v", err)
+		}
+
+		newFinalizers := make([]string, 0, len(freshNAD.Finalizers))
+		for _, f := range freshNAD.Finalizers {
+			if f != finalizer {
+				newFinalizers = append(newFinalizers, f)
+			}
+		}
+
+		if len(newFinalizers) == len(freshNAD.Finalizers) {
+			return true, nil // finalizer not present
+		}
+
+		freshNAD.Finalizers = newFinalizers
+		if err := d.kubeClient.UpdateNetworkAttachmentDefinition(freshNAD); err != nil {
+			if kerrors.IsConflict(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("failed to remove finalizer from NAD: %v", err)
+		}
+
+		log.Info().Msgf("Removed finalizer %s from NAD %s/%s", finalizer, nad.Namespace, nad.Name)
+		return true, nil
+	})
+}
+
+// hasNADFinalizer checks if a NAD has a specific finalizer
+func hasNADFinalizer(nad *v1.NetworkAttachmentDefinition, finalizer string) bool {
+	for _, f := range nad.Finalizers {
+		if f == finalizer {
+			return true
+		}
+	}
+	return false
+}
+
+// processPartitionPods handles pod processing for partition-aware plugins.
+// Uses hardware PF GUIDs from GetNodeIBDevices instead of pool-allocated GUIDs.
+// Handles ErrPending from AddGuidsToPKey for non-blocking backend provisioning.
+func (d *daemon) processPartitionPods(
+	pods []*kapi.Pod,
+	networkName string,
+	partitionKey string,
+	netMap networksMap,
+	addMap *utils.SynchronizedMap,
+	networkID string,
+) {
+	if d.fabricClient == nil {
+		log.Debug().Str("network_id", networkID).Msg("fabric client unavailable, skipping partition add")
+		return
+	}
+
+	pKey, err := utils.ParsePKey(partitionKey)
+	if err != nil {
+		log.Error().Msgf("failed to parse partition key %s: %v", partitionKey, err)
+		return
+	}
+
+	allProcessed := true
+	for _, pod := range pods {
+		// Get hardware GUIDs for this pod's node
+		devices, devErr := d.fabricClient.GetNodeIBDevices(pod.Spec.NodeName)
+		if devErr != nil {
+			log.Error().Str("node", pod.Spec.NodeName).Err(devErr).
+				Msg("failed to get IB devices for node")
+			allProcessed = false
+			continue
+		}
+
+		// Collect all PF GUIDs for this node
+		guids := make([]net.HardwareAddr, 0, len(devices))
+		for _, dev := range devices {
+			guids = append(guids, dev.GUID)
+		}
+
+		if len(guids) == 0 {
+			log.Warn().Str("node", pod.Spec.NodeName).
+				Str("pod", pod.Name).Str("namespace", pod.Namespace).
+				Msg("no IB devices found on node")
+			allProcessed = false
+			continue
+		}
+
+		// Call AddGuidsToPKey — may return ErrPending
+		addErr := d.smClient.AddGuidsToPKey(pKey, guids)
+		if addErr != nil {
+			if errors.Is(addErr, plugins.ErrPending) {
+				log.Debug().Str("pod", pod.Name).Str("namespace", pod.Namespace).
+					Str("node", pod.Spec.NodeName).Int("interfaces", len(guids)).
+					Msg("backend provisioning pending")
+				allProcessed = false
+				continue
+			}
+			log.Error().Str("pod", pod.Name).Str("namespace", pod.Namespace).
+				Err(addErr).Msg("AddGuidsToPKey failed")
+			allProcessed = false
+			continue
+		}
+
+		// Success — annotate pod (log once per pod, not per interface)
+		podNetworkInfos, piErr := getAllPodNetworkInfos(networkName, pod, netMap)
+		if piErr != nil {
+			log.Error().Err(piErr).Msg("failed to get pod network infos")
+			allProcessed = false
+			continue
+		}
+
+		log.Info().Str("pod", pod.Name).Str("namespace", pod.Namespace).
+			Str("node", pod.Spec.NodeName).Str("network", networkName).
+			Str("pkey", partitionKey).Int("interfaces", len(podNetworkInfos)).
+			Msg("IB ready, annotating pod")
+
+		// PF mode: only set mellanox.infiniband.app=configured (no pkey in cni-args).
+		// pi.addr is unset, so the removedGUIDList sink stays empty.
+		var removedGUIDList []net.HardwareAddr
+		for _, pi := range podNetworkInfos {
+			if updateErr := d.updatePodNetworkAnnotation(pi, &removedGUIDList, ""); updateErr != nil {
+				log.Error().Err(updateErr).Msg("failed to update pod annotation")
+				allProcessed = false
+			}
+		}
+	}
+
+	if allProcessed {
+		addMap.UnSafeRemove(networkID)
+	}
 }
 
 // getCachedNAD retrieves NAD from cache, falling back to API if not cached
 func (d *daemon) getCachedNAD(networkID string) (*v1.NetworkAttachmentDefinition, error) {
 	// First check cache
-	if nad, exists := d.nadCache[networkID]; exists {
-		return nad, nil
+	if val, exists := d.nadCache.Load(networkID); exists {
+		return val.(*v1.NetworkAttachmentDefinition), nil
 	}
 
 	// Fall back to API call (existing behavior)
@@ -837,17 +1318,21 @@ func (d *daemon) getCachedNAD(networkID string) (*v1.NetworkAttachmentDefinition
 		var getErr error
 		netAttInfo, getErr = d.kubeClient.GetNetworkAttachmentDefinition(networkNamespace, networkName)
 		if getErr != nil {
-			log.Warn().Msgf("failed to get network attachment %s with error %v", networkName, getErr)
-			// keep retrying until backoff exhausted
+			if kerrors.IsNotFound(getErr) {
+				// NAD deleted (teardown) — stop retrying
+				return false, getErr
+			}
+			log.Warn().Str("namespace", networkNamespace).Str("name", networkName).Err(getErr).
+				Msg("failed to get network attachment, retrying")
 			return false, nil
 		}
 		return true, nil
 	}); err != nil {
-		return nil, fmt.Errorf("failed to get network attachment %s", networkName)
+		return nil, fmt.Errorf("failed to get network attachment %s/%s: %w", networkNamespace, networkName, err)
 	}
 
 	// Cache the result
-	d.nadCache[networkID] = netAttInfo
+	d.cacheNAD(networkID, netAttInfo)
 
 	return netAttInfo, nil
 }

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -21,24 +21,36 @@ import (
 	"net"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/Mellanox/ib-kubernetes/pkg/config"
 	"github.com/Mellanox/ib-kubernetes/pkg/guid"
 	k8sMocks "github.com/Mellanox/ib-kubernetes/pkg/k8s-client/mocks"
+	"github.com/Mellanox/ib-kubernetes/pkg/sm/plugins"
 	"github.com/Mellanox/ib-kubernetes/pkg/utils"
 	v1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	testifyMock "github.com/stretchr/testify/mock"
 	kapi "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 // Enhanced mock for SubnetManagerClient
 type mockSMClient struct {
+	addGuidsToPKeyError      error
+	addGuidsCallCount        int
+	addGuidsPKey             int
+	addGuids                 []net.HardwareAddr
 	name                     string
 	removeGuidsFromPKeyError error
 	removeGuidsCallCount     int
+	removeGuidsPKey          int
+	removedGuids             []net.HardwareAddr
 	listGuidsInUseResult     map[string]string
 	listGuidsInUseError      error
 	validateError            error
@@ -57,11 +69,16 @@ func (m *mockSMClient) Validate() error {
 }
 
 func (m *mockSMClient) AddGuidsToPKey(pkey int, guids []net.HardwareAddr) error {
-	return nil
+	m.addGuidsCallCount++
+	m.addGuidsPKey = pkey
+	m.addGuids = cloneHardwareAddrs(guids)
+	return m.addGuidsToPKeyError
 }
 
 func (m *mockSMClient) RemoveGuidsFromPKey(pkey int, guids []net.HardwareAddr) error {
 	m.removeGuidsCallCount++
+	m.removeGuidsPKey = pkey
+	m.removedGuids = cloneHardwareAddrs(guids)
 	return m.removeGuidsFromPKeyError
 }
 
@@ -70,6 +87,78 @@ func (m *mockSMClient) ListGuidsInUse() (map[string]string, error) {
 		return map[string]string{}, m.listGuidsInUseError
 	}
 	return m.listGuidsInUseResult, m.listGuidsInUseError
+}
+
+func cloneHardwareAddrs(guids []net.HardwareAddr) []net.HardwareAddr {
+	if guids == nil {
+		return nil
+	}
+	cloned := make([]net.HardwareAddr, len(guids))
+	for i := range guids {
+		cloned[i] = append(net.HardwareAddr(nil), guids[i]...)
+	}
+	return cloned
+}
+
+// mockFabricClient extends mockSMClient with FabricClient methods for partition-aware tests
+type mockFabricClient struct {
+	mockSMClient
+
+	// CreateIBPartition
+	createPartitionKey    string
+	createPartitionError  error
+	createPartitionCalls  int
+	createdPartitionNames []string
+
+	// DeleteIBPartition
+	deletePartitionError  error
+	deletePartitionCalls  int
+	deletedPartitionNames []string
+
+	// IsPartitionReady
+	partitionReady      bool
+	partitionReadyKey   string
+	partitionReadyErr   error
+	isReadyCalls        int
+	readyPartitionNames []string
+
+	// GetNodeIBDevices
+	nodeIBDevices      []plugins.IBDeviceGUID
+	nodeIBDevicesErr   error
+	getDevicesCalls    int
+	requestedNodeNames []string
+}
+
+func (m *mockFabricClient) CreateIBPartition(name string) (string, error) {
+	m.createPartitionCalls++
+	m.createdPartitionNames = append(m.createdPartitionNames, name)
+	return m.createPartitionKey, m.createPartitionError
+}
+
+func (m *mockFabricClient) DeleteIBPartition(name string) error {
+	m.deletePartitionCalls++
+	m.deletedPartitionNames = append(m.deletedPartitionNames, name)
+	return m.deletePartitionError
+}
+
+func (m *mockFabricClient) IsPartitionReady(name string) (bool, string, error) {
+	m.isReadyCalls++
+	m.readyPartitionNames = append(m.readyPartitionNames, name)
+	return m.partitionReady, m.partitionReadyKey, m.partitionReadyErr
+}
+
+func (m *mockFabricClient) GetNodeIBDevices(nodeName string) ([]plugins.IBDeviceGUID, error) {
+	m.getDevicesCalls++
+	m.requestedNodeNames = append(m.requestedNodeNames, nodeName)
+	return m.nodeIBDevices, m.nodeIBDevicesErr
+}
+
+func useFastBackoff() {
+	originalBackoff := backoffValues
+	backoffValues = wait.Backoff{Duration: time.Millisecond, Factor: 1, Steps: 2}
+	DeferCleanup(func() {
+		backoffValues = originalBackoff
+	})
 }
 
 var _ = Describe("Daemon", func() {
@@ -714,6 +803,647 @@ var _ = Describe("Daemon", func() {
 				ContainSubstring("client"),
 				ContainSubstring("plugin"),
 			))
+		})
+	})
+
+	Context("isPartitionManagedNAD", func() {
+		var partitionDaemon *daemon
+
+		BeforeEach(func() {
+			partitionDaemon = &daemon{}
+		})
+
+		It("returns true when NAD has ibKubernetesEnabled set to true", func() {
+			nad := &v1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ib-partition-net",
+					Namespace: "default",
+				},
+				Spec: v1.NetworkAttachmentDefinitionSpec{
+					Config: `{"type":"ib-sriov","ibKubernetesEnabled":true,"pkey":"0x5005"}`,
+				},
+			}
+			partitionDaemon.nadCache.Store("default_ib-partition-net", nad)
+
+			result := partitionDaemon.isPartitionManagedNAD("default_ib-partition-net")
+			Expect(result).To(BeTrue())
+		})
+
+		It("returns false when NAD lacks ibKubernetesEnabled", func() {
+			nad := &v1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ib-legacy-net",
+					Namespace: "default",
+				},
+				Spec: v1.NetworkAttachmentDefinitionSpec{
+					Config: `{"type":"ib-sriov","pkey":"0x5005"}`,
+				},
+			}
+			partitionDaemon.nadCache.Store("default_ib-legacy-net", nad)
+
+			result := partitionDaemon.isPartitionManagedNAD("default_ib-legacy-net")
+			Expect(result).To(BeFalse())
+		})
+
+		It("returns false when NAD is not in cache", func() {
+			result := partitionDaemon.isPartitionManagedNAD("default_nonexistent-net")
+			Expect(result).To(BeFalse())
+		})
+
+		It("returns false when NAD spec config is malformed JSON", func() {
+			nad := &v1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ib-bad-config",
+					Namespace: "default",
+				},
+				Spec: v1.NetworkAttachmentDefinitionSpec{
+					Config: `{not valid json`,
+				},
+			}
+			partitionDaemon.nadCache.Store("default_ib-bad-config", nad)
+
+			result := partitionDaemon.isPartitionManagedNAD("default_ib-bad-config")
+			Expect(result).To(BeFalse())
+		})
+
+		It("returns false when ibKubernetesEnabled is set to false", func() {
+			nad := &v1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ib-disabled-net",
+					Namespace: "default",
+				},
+				Spec: v1.NetworkAttachmentDefinitionSpec{
+					Config: `{"type":"ib-sriov","ibKubernetesEnabled":false,"pkey":"0x5005"}`,
+				},
+			}
+			partitionDaemon.nadCache.Store("default_ib-disabled-net", nad)
+
+			result := partitionDaemon.isPartitionManagedNAD("default_ib-disabled-net")
+			Expect(result).To(BeFalse())
+		})
+
+		It("returns false when NAD config is empty string", func() {
+			nad := &v1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ib-empty-config",
+					Namespace: "default",
+				},
+				Spec: v1.NetworkAttachmentDefinitionSpec{
+					Config: "",
+				},
+			}
+			partitionDaemon.nadCache.Store("default_ib-empty-config", nad)
+
+			result := partitionDaemon.isPartitionManagedNAD("default_ib-empty-config")
+			Expect(result).To(BeFalse())
+		})
+
+		It("uses the cached ibKubernetesEnabled decision after caching a NAD", func() {
+			nad := &v1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ib-cached-net",
+					Namespace: "default",
+				},
+				Spec: v1.NetworkAttachmentDefinitionSpec{
+					Config: `{"type":"ib-sriov","ibKubernetesEnabled":true}`,
+				},
+			}
+			partitionDaemon.cacheNAD("default_ib-cached-net", nad)
+			nad.Spec.Config = `{"type":"ib-sriov","ibKubernetesEnabled":false}`
+
+			result := partitionDaemon.isPartitionManagedNAD("default_ib-cached-net")
+			Expect(result).To(BeTrue())
+		})
+	})
+
+	Context("getPartitionKeyFromNAD", func() {
+		var partitionDaemon *daemon
+
+		BeforeEach(func() {
+			partitionDaemon = &daemon{}
+		})
+
+		It("returns partition key from NAD annotation", func() {
+			nad := &v1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ib-partition-net",
+					Namespace: "default",
+					Annotations: map[string]string{
+						utils.PartitionKeyAnnotation: "0x500A",
+					},
+				},
+				Spec: v1.NetworkAttachmentDefinitionSpec{
+					Config: `{"type":"ib-sriov","ibKubernetesEnabled":true,"pkey":"0x5005"}`,
+				},
+			}
+			partitionDaemon.nadCache.Store("default_ib-partition-net", nad)
+
+			pkey := partitionDaemon.getPartitionKeyFromNAD("default_ib-partition-net")
+			Expect(pkey).To(Equal("0x500A"))
+		})
+
+		It("returns empty string when NAD has no partition key annotation", func() {
+			nad := &v1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ib-no-pkey-net",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"some-other-annotation": "value",
+					},
+				},
+				Spec: v1.NetworkAttachmentDefinitionSpec{
+					Config: `{"type":"ib-sriov","ibKubernetesEnabled":true}`,
+				},
+			}
+			partitionDaemon.nadCache.Store("default_ib-no-pkey-net", nad)
+
+			pkey := partitionDaemon.getPartitionKeyFromNAD("default_ib-no-pkey-net")
+			Expect(pkey).To(BeEmpty())
+		})
+
+		It("returns empty string when NAD not in cache", func() {
+			pkey := partitionDaemon.getPartitionKeyFromNAD("default_nonexistent-net")
+			Expect(pkey).To(BeEmpty())
+		})
+
+		It("returns empty string when NAD has nil annotations", func() {
+			nad := &v1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ib-nil-annot-net",
+					Namespace: "default",
+				},
+				Spec: v1.NetworkAttachmentDefinitionSpec{
+					Config: `{"type":"ib-sriov","ibKubernetesEnabled":true}`,
+				},
+			}
+			partitionDaemon.nadCache.Store("default_ib-nil-annot-net", nad)
+
+			pkey := partitionDaemon.getPartitionKeyFromNAD("default_ib-nil-annot-net")
+			Expect(pkey).To(BeEmpty())
+		})
+	})
+
+	Context("mockFabricClient interface compliance", func() {
+		It("implements FabricClient interface", func() {
+			mock := &mockFabricClient{}
+			// Compile-time check: mockFabricClient satisfies plugins.FabricClient
+			var _ plugins.FabricClient = mock
+			Expect(mock).ToNot(BeNil())
+		})
+
+		It("tracks call counts and returns configured values", func() {
+			mock := &mockFabricClient{
+				createPartitionKey: "0x600A",
+				partitionReady:     true,
+				partitionReadyKey:  "0x600A",
+				nodeIBDevices: []plugins.IBDeviceGUID{
+					{Device: "mlx5_0", DeviceInstance: 0, GUID: net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}},
+				},
+			}
+
+			key, err := mock.CreateIBPartition("default_test-net")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(key).To(Equal("0x600A"))
+			Expect(mock.createPartitionCalls).To(Equal(1))
+
+			err = mock.DeleteIBPartition("default_test-net")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(mock.deletePartitionCalls).To(Equal(1))
+
+			ready, pkey, err := mock.IsPartitionReady("default_test-net")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ready).To(BeTrue())
+			Expect(pkey).To(Equal("0x600A"))
+			Expect(mock.isReadyCalls).To(Equal(1))
+
+			devices, err := mock.GetNodeIBDevices("node-1")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(devices).To(HaveLen(1))
+			Expect(devices[0].Device).To(Equal("mlx5_0"))
+			Expect(mock.getDevicesCalls).To(Equal(1))
+		})
+	})
+
+	Context("daemon with fabricClient field", func() {
+		It("can be constructed with a fabricClient", func() {
+			mock := &mockFabricClient{
+				mockSMClient: mockSMClient{name: "test-fabric"},
+			}
+
+			d := &daemon{
+				smClient:          mock,
+				fabricClient:      mock,
+				guidPodNetworkMap: make(map[string]string),
+			}
+
+			Expect(d.fabricClient).ToNot(BeNil())
+			Expect(d.smClient.Name()).To(Equal("test-fabric"))
+		})
+
+		It("fabricClient is nil when plugin does not implement FabricClient", func() {
+			sm := &mockSMClient{name: "legacy-sm"}
+
+			d := &daemon{
+				smClient:          sm,
+				fabricClient:      nil,
+				guidPodNetworkMap: make(map[string]string),
+			}
+
+			Expect(d.fabricClient).To(BeNil())
+		})
+	})
+
+	Context("updatePodNetworkAnnotation error propagation", func() {
+		var mockK8sClient *k8sMocks.Client
+
+		BeforeEach(func() {
+			mockK8sClient = &k8sMocks.Client{}
+			testDaemon.kubeClient = mockK8sClient
+		})
+
+		It("returns a non-nil error when SetAnnotationsOnPod fails", func() {
+			pod := &kapi.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "p1", Namespace: "ns1", UID: "uid-1",
+					Annotations: map[string]string{},
+				},
+			}
+			addr, parseErr := net.ParseMAC("02:00:00:00:00:00:00:09")
+			Expect(parseErr).ToNot(HaveOccurred())
+
+			pi := &podNetworkInfo{
+				pod:       pod,
+				ibNetwork: &v1.NetworkSelectionElement{Name: "n1"},
+				networks:  []*v1.NetworkSelectionElement{{Name: "n1"}},
+				addr:      addr,
+			}
+
+			// Use a NotFound error so the backoff loop exits on the first attempt
+			// (the IsNotFound branch returns false, err immediately) — keeps the
+			// test fast while still exercising the new error-propagation path.
+			gr := schema.GroupResource{Resource: "pods"}
+			mockK8sClient.On(
+				"SetAnnotationsOnPod", pod, pod.Annotations,
+			).Return(kerrors.NewNotFound(gr, "p1"))
+
+			var removed []net.HardwareAddr
+			err := testDaemon.updatePodNetworkAnnotation(pi, &removed, "0x1234")
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("ns1/p1"))
+			Expect(removed).To(ContainElement(addr))
+		})
+
+		It("does not try to release a GUID when PF-mode annotation updates fail", func() {
+			pod := &kapi.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "p1", Namespace: "ns1", UID: "uid-1",
+					Annotations: map[string]string{},
+				},
+			}
+			pi := &podNetworkInfo{
+				pod:       pod,
+				ibNetwork: &v1.NetworkSelectionElement{Name: "n1"},
+				networks:  []*v1.NetworkSelectionElement{{Name: "n1"}},
+			}
+
+			gr := schema.GroupResource{Resource: "pods"}
+			mockK8sClient.On(
+				"SetAnnotationsOnPod", pod, testifyMock.Anything,
+			).Return(kerrors.NewNotFound(gr, "p1"))
+
+			var removed []net.HardwareAddr
+			err := testDaemon.updatePodNetworkAnnotation(pi, &removed, "")
+
+			Expect(err).To(HaveOccurred())
+			Expect(removed).To(BeEmpty())
+		})
+	})
+
+	Context("partition-aware pod processing", func() {
+		var mockK8sClient *k8sMocks.Client
+
+		newPartitionPod := func() *kapi.Pod {
+			return &kapi.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "p1",
+					Namespace: "ns1",
+					UID:       "uid-1",
+					Annotations: map[string]string{
+						v1.NetworkAttachmentAnnot: `[{"name":"ib-net","namespace":"ns1"}]`,
+					},
+				},
+				Spec: kapi.PodSpec{NodeName: "node-1"},
+			}
+		}
+
+		BeforeEach(func() {
+			mockK8sClient = &k8sMocks.Client{}
+		})
+
+		It("keeps the add queue when backend provisioning is pending", func() {
+			fabric := &mockFabricClient{
+				mockSMClient: mockSMClient{
+					name:                "test-fabric",
+					addGuidsToPKeyError: plugins.ErrPending,
+				},
+				nodeIBDevices: []plugins.IBDeviceGUID{
+					{Device: "mlx5_0", GUID: net.HardwareAddr{0x02, 0, 0, 0, 0, 0, 0, 0x01}},
+				},
+			}
+			d := &daemon{smClient: fabric, fabricClient: fabric, kubeClient: mockK8sClient}
+			addMap := utils.NewSynchronizedMap()
+			addMap.Set("ns1_ib-net", []*kapi.Pod{newPartitionPod()})
+
+			d.processPartitionPods(
+				addMap.Items["ns1_ib-net"].([]*kapi.Pod),
+				"ib-net", "0x5ac", networksMap{theMap: map[types.UID][]*v1.NetworkSelectionElement{}},
+				addMap, "ns1_ib-net",
+			)
+
+			_, exists := addMap.Get("ns1_ib-net")
+			Expect(exists).To(BeTrue())
+			Expect(fabric.addGuidsCallCount).To(Equal(1))
+			Expect(fabric.getDevicesCalls).To(Equal(1))
+		})
+
+		It("removes the add queue entry after GUID add and pod annotation succeed", func() {
+			pod := newPartitionPod()
+			fabric := &mockFabricClient{
+				mockSMClient: mockSMClient{name: "test-fabric"},
+				nodeIBDevices: []plugins.IBDeviceGUID{
+					{Device: "mlx5_0", GUID: net.HardwareAddr{0x02, 0, 0, 0, 0, 0, 0, 0x02}},
+				},
+			}
+			mockK8sClient.On("SetAnnotationsOnPod", pod, testifyMock.Anything).Return(nil)
+			d := &daemon{smClient: fabric, fabricClient: fabric, kubeClient: mockK8sClient}
+			addMap := utils.NewSynchronizedMap()
+			addMap.Set("ns1_ib-net", []*kapi.Pod{pod})
+
+			d.processPartitionPods(
+				[]*kapi.Pod{pod}, "ib-net", "0x5ac",
+				networksMap{theMap: map[types.UID][]*v1.NetworkSelectionElement{}},
+				addMap, "ns1_ib-net",
+			)
+
+			_, exists := addMap.Get("ns1_ib-net")
+			Expect(exists).To(BeFalse())
+			Expect(fabric.addGuidsCallCount).To(Equal(1))
+			Expect(fabric.addGuidsPKey).To(Equal(0x5ac))
+			Expect(fabric.addGuids).To(HaveLen(1))
+			Expect(pod.Annotations[v1.NetworkAttachmentAnnot]).To(ContainSubstring(utils.ConfiguredInfiniBandPod))
+		})
+
+		It("keeps the add queue when PF-mode annotation update fails", func() {
+			pod := newPartitionPod()
+			fabric := &mockFabricClient{
+				mockSMClient: mockSMClient{name: "test-fabric"},
+				nodeIBDevices: []plugins.IBDeviceGUID{
+					{Device: "mlx5_0", GUID: net.HardwareAddr{0x02, 0, 0, 0, 0, 0, 0, 0x03}},
+				},
+			}
+			gr := schema.GroupResource{Resource: "pods"}
+			mockK8sClient.On("SetAnnotationsOnPod", pod, testifyMock.Anything).
+				Return(kerrors.NewNotFound(gr, "p1"))
+			d := &daemon{smClient: fabric, fabricClient: fabric, kubeClient: mockK8sClient}
+			addMap := utils.NewSynchronizedMap()
+			addMap.Set("ns1_ib-net", []*kapi.Pod{pod})
+
+			d.processPartitionPods(
+				[]*kapi.Pod{pod}, "ib-net", "0x5ac",
+				networksMap{theMap: map[types.UID][]*v1.NetworkSelectionElement{}},
+				addMap, "ns1_ib-net",
+			)
+
+			_, exists := addMap.Get("ns1_ib-net")
+			Expect(exists).To(BeTrue())
+		})
+
+		It("returns without panicking when FabricClient is absent", func() {
+			addMap := utils.NewSynchronizedMap()
+			addMap.Set("ns1_ib-net", []*kapi.Pod{newPartitionPod()})
+			d := &daemon{smClient: &mockSMClient{name: "legacy-sm"}}
+
+			Expect(func() {
+				d.processPartitionPods(
+					addMap.Items["ns1_ib-net"].([]*kapi.Pod),
+					"ib-net", "0x5ac", networksMap{theMap: map[types.UID][]*v1.NetworkSelectionElement{}},
+					addMap, "ns1_ib-net",
+				)
+			}).ToNot(Panic())
+		})
+	})
+
+	Context("partition-aware pod deletion", func() {
+		It("returns without panicking when FabricClient is absent", func() {
+			d := &daemon{smClient: &mockSMClient{name: "legacy-sm"}}
+			d.cacheNAD("ns1_ib-net", &v1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ib-net",
+					Namespace: "ns1",
+					Annotations: map[string]string{
+						utils.PartitionKeyAnnotation: "0x5ac",
+					},
+				},
+				Spec: v1.NetworkAttachmentDefinitionSpec{
+					Config: `{"type":"ib-sriov","ibKubernetesEnabled":true}`,
+				},
+			})
+
+			Expect(func() {
+				d.deletePartitionPods("ns1_ib-net", []*kapi.Pod{{
+					ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "ns1"},
+					Spec:       kapi.PodSpec{NodeName: "node-1"},
+				}})
+			}).ToNot(Panic())
+		})
+
+		It("removes node PF GUIDs from the partition", func() {
+			fabric := &mockFabricClient{
+				mockSMClient: mockSMClient{name: "test-fabric"},
+				nodeIBDevices: []plugins.IBDeviceGUID{
+					{Device: "mlx5_0", GUID: net.HardwareAddr{0x02, 0, 0, 0, 0, 0, 0, 0x04}},
+					{Device: "mlx5_1", GUID: net.HardwareAddr{0x02, 0, 0, 0, 0, 0, 0, 0x05}},
+				},
+			}
+			d := &daemon{smClient: fabric, fabricClient: fabric}
+			d.cacheNAD("ns1_ib-net", &v1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ib-net",
+					Namespace: "ns1",
+					Annotations: map[string]string{
+						utils.PartitionKeyAnnotation: "0x5ac",
+					},
+				},
+				Spec: v1.NetworkAttachmentDefinitionSpec{
+					Config: `{"type":"ib-sriov","ibKubernetesEnabled":true}`,
+				},
+			})
+
+			d.deletePartitionPods("ns1_ib-net", []*kapi.Pod{{
+				ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "ns1"},
+				Spec:       kapi.PodSpec{NodeName: "node-1"},
+			}})
+
+			Expect(fabric.requestedNodeNames).To(Equal([]string{"node-1"}))
+			Expect(fabric.removeGuidsCallCount).To(Equal(1))
+			Expect(fabric.removeGuidsPKey).To(Equal(0x5ac))
+			Expect(fabric.removedGuids).To(HaveLen(2))
+		})
+	})
+
+	Context("partition NAD setup and deletion", func() {
+		newPartitionNAD := func() *v1.NetworkAttachmentDefinition {
+			return &v1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ib-net",
+					Namespace: "ns1",
+				},
+				Spec: v1.NetworkAttachmentDefinitionSpec{
+					Config: `{"type":"ib-sriov","ibKubernetesEnabled":true}`,
+				},
+			}
+		}
+
+		It("skips setup when the NAD already has a partition key", func() {
+			fabric := &mockFabricClient{
+				mockSMClient:       mockSMClient{name: "test-fabric"},
+				createPartitionKey: "0x5ac",
+			}
+			nad := newPartitionNAD()
+			nad.Annotations = map[string]string{utils.PartitionKeyAnnotation: "0x5ac"}
+			d := &daemon{fabricClient: fabric}
+
+			err := d.setupPartitionForNAD(nad)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fabric.createPartitionCalls).To(Equal(0))
+		})
+
+		It("skips setup for non ib-sriov NADs", func() {
+			fabric := &mockFabricClient{mockSMClient: mockSMClient{name: "test-fabric"}}
+			nad := newPartitionNAD()
+			nad.Spec.Config = `{"type":"sriov","ibKubernetesEnabled":true}`
+			d := &daemon{fabricClient: fabric}
+
+			err := d.setupPartitionForNAD(nad)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fabric.createPartitionCalls).To(Equal(0))
+		})
+
+		It("skips setup when ibKubernetesEnabled is false", func() {
+			fabric := &mockFabricClient{mockSMClient: mockSMClient{name: "test-fabric"}}
+			nad := newPartitionNAD()
+			nad.Spec.Config = `{"type":"ib-sriov","ibKubernetesEnabled":false}`
+			d := &daemon{fabricClient: fabric}
+
+			err := d.setupPartitionForNAD(nad)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fabric.createPartitionCalls).To(Equal(0))
+		})
+
+		It("creates a partition and persists the returned PKey on the NAD", func() {
+			useFastBackoff()
+			fabric := &mockFabricClient{
+				mockSMClient:       mockSMClient{name: "test-fabric"},
+				createPartitionKey: "0x5ac",
+			}
+			mockK8sClient := &k8sMocks.Client{}
+			nad := newPartitionNAD()
+			var updatedNAD *v1.NetworkAttachmentDefinition
+			mockK8sClient.On("GetNetworkAttachmentDefinition", "ns1", "ib-net").
+				Return(nad.DeepCopy(), nil)
+			mockK8sClient.On("UpdateNetworkAttachmentDefinition", testifyMock.Anything).
+				Run(func(args testifyMock.Arguments) {
+					updatedNAD = args.Get(0).(*v1.NetworkAttachmentDefinition)
+				}).Return(nil)
+			d := &daemon{fabricClient: fabric, kubeClient: mockK8sClient}
+
+			err := d.setupPartitionForNAD(nad)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fabric.createdPartitionNames).To(Equal([]string{"ns1_ib-net"}))
+			Expect(updatedNAD).ToNot(BeNil())
+			Expect(updatedNAD.Annotations[utils.PartitionKeyAnnotation]).To(Equal("0x5ac"))
+			Expect(updatedNAD.Finalizers).To(ContainElement(utils.PartitionNADFinalizer))
+		})
+
+		It("deletes the backend partition and removes the NAD finalizer", func() {
+			useFastBackoff()
+			fabric := &mockFabricClient{mockSMClient: mockSMClient{name: "test-fabric"}}
+			mockK8sClient := &k8sMocks.Client{}
+			nad := newPartitionNAD()
+			freshNAD := nad.DeepCopy()
+			freshNAD.Finalizers = []string{utils.PartitionNADFinalizer, "other-finalizer"}
+			var updatedNAD *v1.NetworkAttachmentDefinition
+			mockK8sClient.On("GetNetworkAttachmentDefinition", "ns1", "ib-net").
+				Return(freshNAD, nil)
+			mockK8sClient.On("UpdateNetworkAttachmentDefinition", testifyMock.Anything).
+				Run(func(args testifyMock.Arguments) {
+					updatedNAD = args.Get(0).(*v1.NetworkAttachmentDefinition)
+				}).Return(nil)
+			d := &daemon{fabricClient: fabric, kubeClient: mockK8sClient}
+
+			err := d.handleNADDeletion(nad)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fabric.deletedPartitionNames).To(Equal([]string{"ns1_ib-net"}))
+			Expect(updatedNAD.Finalizers).To(Equal([]string{"other-finalizer"}))
+		})
+
+		It("retries finalizer removal on update conflict", func() {
+			useFastBackoff()
+			mockK8sClient := &k8sMocks.Client{}
+			nad := newPartitionNAD()
+			firstFreshNAD := nad.DeepCopy()
+			firstFreshNAD.Finalizers = []string{utils.PartitionNADFinalizer}
+			secondFreshNAD := nad.DeepCopy()
+			secondFreshNAD.Finalizers = []string{utils.PartitionNADFinalizer}
+			conflict := kerrors.NewConflict(
+				schema.GroupResource{Group: "k8s.cni.cncf.io", Resource: "networkattachmentdefinitions"},
+				"ib-net", fmt.Errorf("conflict"),
+			)
+
+			get1 := mockK8sClient.On("GetNetworkAttachmentDefinition", "ns1", "ib-net").
+				Return(firstFreshNAD, nil).Once()
+			update1 := mockK8sClient.On("UpdateNetworkAttachmentDefinition", testifyMock.Anything).
+				Return(conflict).Once().NotBefore(get1)
+			get2 := mockK8sClient.On("GetNetworkAttachmentDefinition", "ns1", "ib-net").
+				Return(secondFreshNAD, nil).Once().NotBefore(update1)
+			mockK8sClient.On("UpdateNetworkAttachmentDefinition", testifyMock.Anything).
+				Return(nil).Once().NotBefore(get2)
+			d := &daemon{kubeClient: mockK8sClient}
+
+			err := d.removeNADFinalizer(nad, utils.PartitionNADFinalizer)
+
+			Expect(err).ToNot(HaveOccurred())
+			mockK8sClient.AssertNumberOfCalls(GinkgoT(), "UpdateNetworkAttachmentDefinition", 2)
+		})
+	})
+
+	Context("getCachedNAD error type preservation", func() {
+		var mockK8sClient *k8sMocks.Client
+
+		BeforeEach(func() {
+			mockK8sClient = &k8sMocks.Client{}
+			testDaemon.kubeClient = mockK8sClient
+		})
+
+		It("returns an error that satisfies kerrors.IsNotFound when NAD missing", func() {
+			gr := schema.GroupResource{Group: "k8s.cni.cncf.io", Resource: "networkattachmentdefinitions"}
+			notFoundErr := kerrors.NewNotFound(gr, "n1")
+
+			mockK8sClient.On(
+				"GetNetworkAttachmentDefinition", "ns1", "n1",
+			).Return(nil, notFoundErr)
+
+			_, err := testDaemon.getCachedNAD("ns1_n1")
+
+			Expect(err).To(HaveOccurred())
+			Expect(kerrors.IsNotFound(err)).To(BeTrue(),
+				"expected wrapped error to satisfy kerrors.IsNotFound; got %v", err)
 		})
 	})
 })

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -28,6 +28,8 @@ import (
 	k8sMocks "github.com/Mellanox/ib-kubernetes/pkg/k8s-client/mocks"
 	"github.com/Mellanox/ib-kubernetes/pkg/sm/plugins"
 	"github.com/Mellanox/ib-kubernetes/pkg/utils"
+	"github.com/Mellanox/ib-kubernetes/pkg/watcher"
+	resEventHandler "github.com/Mellanox/ib-kubernetes/pkg/watcher/handler"
 	v1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -35,6 +37,7 @@ import (
 	kapi "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -161,11 +164,33 @@ func useFastBackoff() {
 	})
 }
 
+// stubWatcher / stubEventHandler are minimal in-package fakes for exercising
+// AddPeriodicUpdate / DeletePeriodicUpdate without standing up an informer.
+type stubWatcher struct {
+	handler resEventHandler.ResourceEventHandler
+}
+
+func (s *stubWatcher) RunBackground() watcher.StopFunc            { return func() {} }
+func (s *stubWatcher) GetHandler() resEventHandler.ResourceEventHandler { return s.handler }
+
+type stubEventHandler struct {
+	addMap    *utils.SynchronizedMap
+	deleteMap *utils.SynchronizedMap
+}
+
+func (s *stubEventHandler) GetResourceObject() runtime.Object { return nil }
+func (s *stubEventHandler) GetResults() (*utils.SynchronizedMap, *utils.SynchronizedMap) {
+	return s.addMap, s.deleteMap
+}
+func (s *stubEventHandler) OnAdd(_ interface{}, _ bool) {}
+func (s *stubEventHandler) OnUpdate(_, _ interface{})   {}
+func (s *stubEventHandler) OnDelete(_ interface{})      {}
+
 var _ = Describe("Daemon", func() {
 	var (
 		mockClient    *mockSMClient
 		guidPool      guid.Pool
-		testDaemon    *daemon
+		testPodCtrl   *podController
 		testGUID      = "02:00:00:00:00:00:00:01"
 		testPKey      = "0x1234"
 		testUID       = types.UID("test-pod-uid")
@@ -190,18 +215,18 @@ var _ = Describe("Daemon", func() {
 		guidPool, err = guid.NewPool(poolConfig)
 		Expect(err).ToNot(HaveOccurred())
 
-		testDaemon = &daemon{
+		testPodCtrl = &podController{
+			smClient:          mockClient,
 			guidPool:          guidPool,
 			guidPodNetworkMap: make(map[string]string),
-			smClient:          mockClient,
 		}
 	})
 
 	Context("allocatePodNetworkGUID", func() {
 		It("allocates new GUID successfully", func() {
-			err := testDaemon.allocatePodNetworkGUID(testGUID, testNetworkID, testUID, testPKey)
+			err := testPodCtrl.allocatePodNetworkGUID(testGUID, testNetworkID, testUID, testPKey)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(testDaemon.guidPodNetworkMap[testGUID]).To(Equal(testNetworkID))
+			Expect(testPodCtrl.guidPodNetworkMap[testGUID]).To(Equal(testNetworkID))
 
 			pkey, err := guidPool.Get(testGUID)
 			Expect(err).ToNot(HaveOccurred())
@@ -209,17 +234,17 @@ var _ = Describe("Daemon", func() {
 		})
 
 		It("returns error when GUID already allocated to different network", func() {
-			testDaemon.guidPodNetworkMap[testGUID] = "different-network"
+			testPodCtrl.guidPodNetworkMap[testGUID] = "different-network"
 
-			err := testDaemon.allocatePodNetworkGUID(testGUID, testNetworkID, testUID, testPKey)
+			err := testPodCtrl.allocatePodNetworkGUID(testGUID, testNetworkID, testUID, testPKey)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("already allocated"))
 		})
 
 		It("succeeds when GUID already allocated to same network", func() {
-			testDaemon.guidPodNetworkMap[testGUID] = testNetworkID
+			testPodCtrl.guidPodNetworkMap[testGUID] = testNetworkID
 
-			err := testDaemon.allocatePodNetworkGUID(testGUID, testNetworkID, testUID, testPKey)
+			err := testPodCtrl.allocatePodNetworkGUID(testGUID, testNetworkID, testUID, testPKey)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -227,12 +252,12 @@ var _ = Describe("Daemon", func() {
 			oldPKey := "0x5678"
 			err := guidPool.AllocateGUID(testGUID, oldPKey)
 			Expect(err).ToNot(HaveOccurred())
-			testDaemon.guidPodNetworkMap[testGUID] = "old-network"
+			testPodCtrl.guidPodNetworkMap[testGUID] = "old-network"
 
-			err = testDaemon.allocatePodNetworkGUID(testGUID, testNetworkID, testUID, testPKey)
+			err = testPodCtrl.allocatePodNetworkGUID(testGUID, testNetworkID, testUID, testPKey)
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(testDaemon.guidPodNetworkMap[testGUID]).To(Equal(testNetworkID))
+			Expect(testPodCtrl.guidPodNetworkMap[testGUID]).To(Equal(testNetworkID))
 			pkey, err := guidPool.Get(testGUID)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pkey).To(Equal(testPKey))
@@ -243,7 +268,7 @@ var _ = Describe("Daemon", func() {
 			oldPKey := "0x5678"
 			err := guidPool.AllocateGUID(testGUID, oldPKey)
 			Expect(err).ToNot(HaveOccurred())
-			testDaemon.guidPodNetworkMap[testGUID] = "old-network"
+			testPodCtrl.guidPodNetworkMap[testGUID] = "old-network"
 
 			// Make the mock fail first few times then succeed to avoid infinite backoff
 			mockClient.removeGuidsFromPKeyError = fmt.Errorf("sm error")
@@ -254,7 +279,7 @@ var _ = Describe("Daemon", func() {
 		})
 
 		It("returns error for invalid GUID format", func() {
-			err := testDaemon.allocatePodNetworkGUID("invalid-guid", testNetworkID, testUID, testPKey)
+			err := testPodCtrl.allocatePodNetworkGUID("invalid-guid", testNetworkID, testUID, testPKey)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to allocate GUID"))
 		})
@@ -294,7 +319,7 @@ var _ = Describe("Daemon", func() {
 
 		BeforeEach(func() {
 			mockK8sClient = &k8sMocks.Client{}
-			testDaemon.kubeClient = mockK8sClient
+			testPodCtrl.kubeClient = mockK8sClient
 		})
 
 		It("successfully initializes GUID pool from running pods", func() {
@@ -325,7 +350,7 @@ var _ = Describe("Daemon", func() {
 			// and then syncs with an empty SM (all GUIDs are new)
 			mockClient.listGuidsInUseResult = map[string]string{}
 
-			err := testDaemon.initGUIDPool()
+			err := testPodCtrl.initGUIDPool()
 			Expect(err).ToNot(HaveOccurred())
 
 			// In this scenario:
@@ -333,7 +358,7 @@ var _ = Describe("Daemon", func() {
 			// 2. SM sync finds no GUIDs in use
 			// 3. Cleanup phase removes the GUID from map (since not in SM)
 			// This verifies the cleanup logic works as expected
-			Expect(testDaemon.guidPodNetworkMap).To(BeEmpty())
+			Expect(testPodCtrl.guidPodNetworkMap).To(BeEmpty())
 
 			mockK8sClient.AssertExpectations(GinkgoT())
 		})
@@ -346,19 +371,19 @@ var _ = Describe("Daemon", func() {
 			mockK8sClient.On("GetPods", kapi.NamespaceAll).Return(podList, nil)
 
 			// Pre-populate the map as if a pod was processed earlier
-			testDaemon.guidPodNetworkMap["02:00:00:00:00:00:00:05"] = "existing-pod-network"
+			testPodCtrl.guidPodNetworkMap["02:00:00:00:00:00:00:05"] = "existing-pod-network"
 
 			// SM reports this GUID as in use
 			mockClient.listGuidsInUseResult = map[string]string{
 				"02:00:00:00:00:00:00:05": "0x1000",
 			}
 
-			err := testDaemon.initGUIDPool()
+			err := testPodCtrl.initGUIDPool()
 			Expect(err).ToNot(HaveOccurred())
 
 			// GUID should be preserved since SM reports it as in use
-			Expect(testDaemon.guidPodNetworkMap).To(HaveKey("02:00:00:00:00:00:00:05"))
-			Expect(testDaemon.guidPodNetworkMap["02:00:00:00:00:00:00:05"]).To(Equal("existing-pod-network"))
+			Expect(testPodCtrl.guidPodNetworkMap).To(HaveKey("02:00:00:00:00:00:00:05"))
+			Expect(testPodCtrl.guidPodNetworkMap["02:00:00:00:00:00:00:05"]).To(Equal("existing-pod-network"))
 
 			mockK8sClient.AssertExpectations(GinkgoT())
 		})
@@ -386,11 +411,11 @@ var _ = Describe("Daemon", func() {
 			mockK8sClient.On("GetPods", kapi.NamespaceAll).Return(podList, nil)
 			mockClient.listGuidsInUseResult = map[string]string{}
 
-			err := testDaemon.initGUIDPool()
+			err := testPodCtrl.initGUIDPool()
 			Expect(err).ToNot(HaveOccurred())
 
 			// Verify finished pod's GUID was not added to the map (since pod is finished)
-			Expect(testDaemon.guidPodNetworkMap).ToNot(HaveKey("02:00:00:00:00:00:00:03"))
+			Expect(testPodCtrl.guidPodNetworkMap).ToNot(HaveKey("02:00:00:00:00:00:00:03"))
 
 			mockK8sClient.AssertExpectations(GinkgoT())
 		})
@@ -417,7 +442,7 @@ var _ = Describe("Daemon", func() {
 			mockK8sClient.On("GetPods", kapi.NamespaceAll).Return(podList, nil)
 			mockClient.listGuidsInUseResult = map[string]string{}
 
-			err := testDaemon.initGUIDPool()
+			err := testPodCtrl.initGUIDPool()
 			Expect(err).ToNot(HaveOccurred()) // Should continue despite invalid annotations
 
 			mockK8sClient.AssertExpectations(GinkgoT())
@@ -426,7 +451,7 @@ var _ = Describe("Daemon", func() {
 		It("removes stale GUIDs not in subnet manager", func() {
 			// Setup: add a GUID to the map but NOT to the pool
 			// This simulates a GUID that was allocated but the pool was reset
-			testDaemon.guidPodNetworkMap["02:00:00:00:00:00:00:04"] = "stale-pod-network"
+			testPodCtrl.guidPodNetworkMap["02:00:00:00:00:00:00:04"] = "stale-pod-network"
 
 			podList := &kapi.PodList{Items: []kapi.Pod{}}
 			mockK8sClient.On("GetPods", kapi.NamespaceAll).Return(podList, nil)
@@ -434,12 +459,12 @@ var _ = Describe("Daemon", func() {
 			// SM doesn't have this GUID, so it should be cleaned up but will fail
 			mockClient.listGuidsInUseResult = map[string]string{}
 
-			err := testDaemon.initGUIDPool()
+			err := testPodCtrl.initGUIDPool()
 			Expect(err).ToNot(HaveOccurred())
 
 			// With current logic: GUID is NOT removed because pool release fails
 			// This is the conservative behavior - only remove if we can properly clean up
-			Expect(testDaemon.guidPodNetworkMap).To(HaveKey("02:00:00:00:00:00:00:04"))
+			Expect(testPodCtrl.guidPodNetworkMap).To(HaveKey("02:00:00:00:00:00:00:04"))
 
 			mockK8sClient.AssertExpectations(GinkgoT())
 		})
@@ -451,7 +476,7 @@ var _ = Describe("Daemon", func() {
 			mockK8sClient.On("GetPods", kapi.NamespaceAll).Return(&kapi.PodList{Items: []kapi.Pod{}}, nil).NotBefore(call2)
 			mockClient.listGuidsInUseResult = map[string]string{}
 
-			err := testDaemon.initGUIDPool()
+			err := testPodCtrl.initGUIDPool()
 			Expect(err).ToNot(HaveOccurred()) // Should succeed on the 3rd try
 
 			mockK8sClient.AssertExpectations(GinkgoT())
@@ -462,7 +487,7 @@ var _ = Describe("Daemon", func() {
 			mockK8sClient.On("GetPods", kapi.NamespaceAll).Return(podList, nil)
 			mockClient.listGuidsInUseError = fmt.Errorf("sm error")
 
-			err := testDaemon.initGUIDPool()
+			err := testPodCtrl.initGUIDPool()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("sm error"))
 
@@ -502,7 +527,7 @@ var _ = Describe("Daemon", func() {
 			mockK8sClient.On("GetPods", kapi.NamespaceAll).Return(podList, nil)
 			mockClient.listGuidsInUseResult = map[string]string{}
 
-			err := testDaemon.initGUIDPool()
+			err := testPodCtrl.initGUIDPool()
 			Expect(err).ToNot(HaveOccurred())
 
 			mockK8sClient.AssertExpectations(GinkgoT())
@@ -530,7 +555,7 @@ var _ = Describe("Daemon", func() {
 				"02:00:00:00:00:00:00:32": "0x7fff",
 			}
 
-			err := testDaemon.initGUIDPool()
+			err := testPodCtrl.initGUIDPool()
 			Expect(err).ToNot(HaveOccurred())
 
 			netMap := networksMap{theMap: make(map[types.UID][]*v1.NetworkSelectionElement)}
@@ -540,7 +565,7 @@ var _ = Describe("Daemon", func() {
 
 			spec := &utils.IbSriovCniSpec{PKey: "0x7fff"}
 			for _, pi := range podNetworkInfos {
-				err = testDaemon.processNetworkGUID("ib-sriov-network", spec, pi)
+				err = testPodCtrl.processNetworkGUID("ib-sriov-network", spec, pi)
 				Expect(err).ToNot(HaveOccurred())
 			}
 
@@ -551,27 +576,27 @@ var _ = Describe("Daemon", func() {
 	Context("syncWithSubnetManager", func() {
 		It("successfully syncs with subnet manager", func() {
 			// Setup some GUIDs in the map but not in the pool (simulates post-reset state)
-			testDaemon.guidPodNetworkMap["02:00:00:00:00:00:00:06"] = "pod-network-1"
-			testDaemon.guidPodNetworkMap["02:00:00:00:00:00:00:07"] = "pod-network-2"
+			testPodCtrl.guidPodNetworkMap["02:00:00:00:00:00:00:06"] = "pod-network-1"
+			testPodCtrl.guidPodNetworkMap["02:00:00:00:00:00:00:07"] = "pod-network-2"
 
 			// SM reports only one of them as in use
 			mockClient.listGuidsInUseResult = map[string]string{
 				"02:00:00:00:00:00:00:06": "0x1000",
 			}
 
-			err := testDaemon.syncWithSubnetManager()
+			err := testPodCtrl.syncWithSubnetManager()
 			Expect(err).ToNot(HaveOccurred())
 
 			// With current logic: GUID 07 is NOT removed because pool release fails
 			// Both GUIDs remain in the map due to conservative cleanup behavior
-			Expect(testDaemon.guidPodNetworkMap).To(HaveKey("02:00:00:00:00:00:00:06"))
-			Expect(testDaemon.guidPodNetworkMap).To(HaveKey("02:00:00:00:00:00:00:07"))
+			Expect(testPodCtrl.guidPodNetworkMap).To(HaveKey("02:00:00:00:00:00:00:06"))
+			Expect(testPodCtrl.guidPodNetworkMap).To(HaveKey("02:00:00:00:00:00:00:07"))
 		})
 
 		It("handles subnet manager ListGuidsInUse error", func() {
 			mockClient.listGuidsInUseError = fmt.Errorf("sm list error")
 
-			err := testDaemon.syncWithSubnetManager()
+			err := testPodCtrl.syncWithSubnetManager()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("sm list error"))
 		})
@@ -582,23 +607,23 @@ var _ = Describe("Daemon", func() {
 				"invalid-guid": "0x1000",
 			}
 
-			err := testDaemon.syncWithSubnetManager()
+			err := testPodCtrl.syncWithSubnetManager()
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("handles GUID release error gracefully", func() {
 			// Add a GUID that's not in the pool but is in our map
 			// This simulates an inconsistent state where the map has a GUID but the pool doesn't
-			testDaemon.guidPodNetworkMap["02:00:00:00:00:00:00:08"] = "stale-network"
+			testPodCtrl.guidPodNetworkMap["02:00:00:00:00:00:00:08"] = "stale-network"
 
 			mockClient.listGuidsInUseResult = map[string]string{}
 
-			err := testDaemon.syncWithSubnetManager()
+			err := testPodCtrl.syncWithSubnetManager()
 			Expect(err).ToNot(HaveOccurred())
 
 			// GUID should NOT be removed from map if pool release fails (to prevent data loss)
 			// The daemon logs a warning but keeps the GUID in the map
-			Expect(testDaemon.guidPodNetworkMap).To(HaveKey("02:00:00:00:00:00:00:08"))
+			Expect(testPodCtrl.guidPodNetworkMap).To(HaveKey("02:00:00:00:00:00:00:08"))
 		})
 	})
 
@@ -610,17 +635,17 @@ var _ = Describe("Daemon", func() {
 			// Pre-allocate the GUID with an existing pkey
 			err := guidPool.AllocateGUID(allocatedGUID, existingPkey)
 			Expect(err).ToNot(HaveOccurred())
-			testDaemon.guidPodNetworkMap[allocatedGUID] = "existing-network"
+			testPodCtrl.guidPodNetworkMap[allocatedGUID] = "existing-network"
 
 			// Track initial call count
 			initialCallCount := mockClient.removeGuidsCallCount
 
 			// Remove the stale GUID
-			err = testDaemon.removeStaleGUID(allocatedGUID, existingPkey)
+			err = testPodCtrl.removeStaleGUID(allocatedGUID, existingPkey)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Verify GUID was removed from the map
-			Expect(testDaemon.guidPodNetworkMap).ToNot(HaveKey(allocatedGUID))
+			Expect(testPodCtrl.guidPodNetworkMap).ToNot(HaveKey(allocatedGUID))
 
 			// Verify RemoveGuidsFromPKey was called exactly once
 			Expect(mockClient.removeGuidsCallCount).To(Equal(initialCallCount + 1))
@@ -630,7 +655,7 @@ var _ = Describe("Daemon", func() {
 			allocatedGUID := "02:00:00:00:00:00:00:11"
 			invalidPkey := "invalid-pkey"
 
-			err := testDaemon.removeStaleGUID(allocatedGUID, invalidPkey)
+			err := testPodCtrl.removeStaleGUID(allocatedGUID, invalidPkey)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("invalid pkey"))
 		})
@@ -639,7 +664,7 @@ var _ = Describe("Daemon", func() {
 			invalidGUID := "invalid-guid"
 			existingPkey := "0x1234"
 
-			err := testDaemon.removeStaleGUID(invalidGUID, existingPkey)
+			err := testPodCtrl.removeStaleGUID(invalidGUID, existingPkey)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to parse"))
 		})
@@ -657,13 +682,13 @@ var _ = Describe("Daemon", func() {
 			// Pre-allocate the GUID
 			err := guidPool.AllocateGUID(allocatedGUID, existingPkey)
 			Expect(err).ToNot(HaveOccurred())
-			testDaemon.guidPodNetworkMap[allocatedGUID] = "existing-network"
+			testPodCtrl.guidPodNetworkMap[allocatedGUID] = "existing-network"
 
 			// Make subnet manager fail to remove
 			mockClient.removeGuidsFromPKeyError = fmt.Errorf("sm removal error")
 
 			// Should return error after retries (exponential backoff timeout)
-			err = testDaemon.removeStaleGUID(allocatedGUID, existingPkey)
+			err = testPodCtrl.removeStaleGUID(allocatedGUID, existingPkey)
 			Expect(err).To(HaveOccurred())
 			// The error is from wait.ExponentialBackoff timeout
 			Expect(err.Error()).To(Or(
@@ -676,7 +701,7 @@ var _ = Describe("Daemon", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// GUID should still be in map since removal failed
-			Expect(testDaemon.guidPodNetworkMap).To(HaveKey(allocatedGUID))
+			Expect(testPodCtrl.guidPodNetworkMap).To(HaveKey(allocatedGUID))
 		})
 
 		It("handles pool release failure gracefully", func() {
@@ -685,10 +710,10 @@ var _ = Describe("Daemon", func() {
 
 			// Don't pre-allocate the GUID in the pool, but add to map
 			// This simulates a situation where the pool state is inconsistent
-			testDaemon.guidPodNetworkMap[allocatedGUID] = "existing-network"
+			testPodCtrl.guidPodNetworkMap[allocatedGUID] = "existing-network"
 
 			// Should successfully remove from SM but fail to release from pool
-			err := testDaemon.removeStaleGUID(allocatedGUID, existingPkey)
+			err := testPodCtrl.removeStaleGUID(allocatedGUID, existingPkey)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to release guid"))
 
@@ -704,7 +729,7 @@ var _ = Describe("Daemon", func() {
 
 		BeforeEach(func() {
 			mockK8sClient = &k8sMocks.Client{}
-			testDaemon.kubeClient = mockK8sClient
+			testPodCtrl.kubeClient = mockK8sClient
 		})
 
 		It("calls syncWithSubnetManager at the end", func() {
@@ -715,18 +740,18 @@ var _ = Describe("Daemon", func() {
 			mockK8sClient.On("GetPods", kapi.NamespaceAll).Return(podList, nil)
 
 			// Pre-populate the map
-			testDaemon.guidPodNetworkMap["02:00:00:00:00:00:00:14"] = "test-network"
+			testPodCtrl.guidPodNetworkMap["02:00:00:00:00:00:00:14"] = "test-network"
 
 			// SM returns the GUID as in use
 			mockClient.listGuidsInUseResult = map[string]string{
 				"02:00:00:00:00:00:00:14": "0x1000",
 			}
 
-			err := testDaemon.initGUIDPool()
+			err := testPodCtrl.initGUIDPool()
 			Expect(err).ToNot(HaveOccurred())
 
 			// Verify that the GUID is preserved (syncWithSubnetManager was called)
-			Expect(testDaemon.guidPodNetworkMap).To(HaveKey("02:00:00:00:00:00:00:14"))
+			Expect(testPodCtrl.guidPodNetworkMap).To(HaveKey("02:00:00:00:00:00:00:14"))
 
 			mockK8sClient.AssertExpectations(GinkgoT())
 		})
@@ -738,7 +763,7 @@ var _ = Describe("Daemon", func() {
 			// Make syncWithSubnetManager fail
 			mockClient.listGuidsInUseError = fmt.Errorf("sync error")
 
-			err := testDaemon.initGUIDPool()
+			err := testPodCtrl.initGUIDPool()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("sync error"))
 
@@ -807,10 +832,10 @@ var _ = Describe("Daemon", func() {
 	})
 
 	Context("isPartitionManagedNAD", func() {
-		var partitionDaemon *daemon
+		var partitionCtrl *partitionController
 
 		BeforeEach(func() {
-			partitionDaemon = &daemon{}
+			partitionCtrl = &partitionController{}
 		})
 
 		It("returns true when NAD has ibKubernetesEnabled set to true", func() {
@@ -823,9 +848,9 @@ var _ = Describe("Daemon", func() {
 					Config: `{"type":"ib-sriov","ibKubernetesEnabled":true,"pkey":"0x5005"}`,
 				},
 			}
-			partitionDaemon.nadCache.Store("default_ib-partition-net", nad)
+			partitionCtrl.cacheNAD("default_ib-partition-net", nad)
 
-			result := partitionDaemon.isPartitionManagedNAD("default_ib-partition-net")
+			result := partitionCtrl.IsPartitionManaged("default_ib-partition-net")
 			Expect(result).To(BeTrue())
 		})
 
@@ -839,14 +864,14 @@ var _ = Describe("Daemon", func() {
 					Config: `{"type":"ib-sriov","pkey":"0x5005"}`,
 				},
 			}
-			partitionDaemon.nadCache.Store("default_ib-legacy-net", nad)
+			partitionCtrl.cacheNAD("default_ib-legacy-net", nad)
 
-			result := partitionDaemon.isPartitionManagedNAD("default_ib-legacy-net")
+			result := partitionCtrl.IsPartitionManaged("default_ib-legacy-net")
 			Expect(result).To(BeFalse())
 		})
 
 		It("returns false when NAD is not in cache", func() {
-			result := partitionDaemon.isPartitionManagedNAD("default_nonexistent-net")
+			result := partitionCtrl.IsPartitionManaged("default_nonexistent-net")
 			Expect(result).To(BeFalse())
 		})
 
@@ -860,9 +885,9 @@ var _ = Describe("Daemon", func() {
 					Config: `{not valid json`,
 				},
 			}
-			partitionDaemon.nadCache.Store("default_ib-bad-config", nad)
+			partitionCtrl.cacheNAD("default_ib-bad-config", nad)
 
-			result := partitionDaemon.isPartitionManagedNAD("default_ib-bad-config")
+			result := partitionCtrl.IsPartitionManaged("default_ib-bad-config")
 			Expect(result).To(BeFalse())
 		})
 
@@ -876,9 +901,9 @@ var _ = Describe("Daemon", func() {
 					Config: `{"type":"ib-sriov","ibKubernetesEnabled":false,"pkey":"0x5005"}`,
 				},
 			}
-			partitionDaemon.nadCache.Store("default_ib-disabled-net", nad)
+			partitionCtrl.cacheNAD("default_ib-disabled-net", nad)
 
-			result := partitionDaemon.isPartitionManagedNAD("default_ib-disabled-net")
+			result := partitionCtrl.IsPartitionManaged("default_ib-disabled-net")
 			Expect(result).To(BeFalse())
 		})
 
@@ -892,9 +917,9 @@ var _ = Describe("Daemon", func() {
 					Config: "",
 				},
 			}
-			partitionDaemon.nadCache.Store("default_ib-empty-config", nad)
+			partitionCtrl.cacheNAD("default_ib-empty-config", nad)
 
-			result := partitionDaemon.isPartitionManagedNAD("default_ib-empty-config")
+			result := partitionCtrl.IsPartitionManaged("default_ib-empty-config")
 			Expect(result).To(BeFalse())
 		})
 
@@ -908,19 +933,19 @@ var _ = Describe("Daemon", func() {
 					Config: `{"type":"ib-sriov","ibKubernetesEnabled":true}`,
 				},
 			}
-			partitionDaemon.cacheNAD("default_ib-cached-net", nad)
+			partitionCtrl.cacheNAD("default_ib-cached-net", nad)
 			nad.Spec.Config = `{"type":"ib-sriov","ibKubernetesEnabled":false}`
 
-			result := partitionDaemon.isPartitionManagedNAD("default_ib-cached-net")
+			result := partitionCtrl.IsPartitionManaged("default_ib-cached-net")
 			Expect(result).To(BeTrue())
 		})
 	})
 
 	Context("getPartitionKeyFromNAD", func() {
-		var partitionDaemon *daemon
+		var partitionCtrl *partitionController
 
 		BeforeEach(func() {
-			partitionDaemon = &daemon{}
+			partitionCtrl = &partitionController{}
 		})
 
 		It("returns partition key from NAD annotation", func() {
@@ -936,9 +961,9 @@ var _ = Describe("Daemon", func() {
 					Config: `{"type":"ib-sriov","ibKubernetesEnabled":true,"pkey":"0x5005"}`,
 				},
 			}
-			partitionDaemon.nadCache.Store("default_ib-partition-net", nad)
+			partitionCtrl.cacheNAD("default_ib-partition-net", nad)
 
-			pkey := partitionDaemon.getPartitionKeyFromNAD("default_ib-partition-net")
+			pkey := partitionCtrl.getPartitionKeyFromNAD("default_ib-partition-net")
 			Expect(pkey).To(Equal("0x500A"))
 		})
 
@@ -955,14 +980,14 @@ var _ = Describe("Daemon", func() {
 					Config: `{"type":"ib-sriov","ibKubernetesEnabled":true}`,
 				},
 			}
-			partitionDaemon.nadCache.Store("default_ib-no-pkey-net", nad)
+			partitionCtrl.cacheNAD("default_ib-no-pkey-net", nad)
 
-			pkey := partitionDaemon.getPartitionKeyFromNAD("default_ib-no-pkey-net")
+			pkey := partitionCtrl.getPartitionKeyFromNAD("default_ib-no-pkey-net")
 			Expect(pkey).To(BeEmpty())
 		})
 
 		It("returns empty string when NAD not in cache", func() {
-			pkey := partitionDaemon.getPartitionKeyFromNAD("default_nonexistent-net")
+			pkey := partitionCtrl.getPartitionKeyFromNAD("default_nonexistent-net")
 			Expect(pkey).To(BeEmpty())
 		})
 
@@ -976,9 +1001,9 @@ var _ = Describe("Daemon", func() {
 					Config: `{"type":"ib-sriov","ibKubernetesEnabled":true}`,
 				},
 			}
-			partitionDaemon.nadCache.Store("default_ib-nil-annot-net", nad)
+			partitionCtrl.cacheNAD("default_ib-nil-annot-net", nad)
 
-			pkey := partitionDaemon.getPartitionKeyFromNAD("default_ib-nil-annot-net")
+			pkey := partitionCtrl.getPartitionKeyFromNAD("default_ib-nil-annot-net")
 			Expect(pkey).To(BeEmpty())
 		})
 	})
@@ -1024,32 +1049,23 @@ var _ = Describe("Daemon", func() {
 		})
 	})
 
-	Context("daemon with fabricClient field", func() {
-		It("can be constructed with a fabricClient", func() {
+	Context("partitionController fabric client plumbing", func() {
+		It("retains the FabricClient passed via constructor", func() {
 			mock := &mockFabricClient{
 				mockSMClient: mockSMClient{name: "test-fabric"},
 			}
 
-			d := &daemon{
-				smClient:          mock,
-				fabricClient:      mock,
-				guidPodNetworkMap: make(map[string]string),
-			}
-
-			Expect(d.fabricClient).ToNot(BeNil())
-			Expect(d.smClient.Name()).To(Equal("test-fabric"))
+			pc := newPartitionController(mock, mock, nil, nil)
+			Expect(pc.fabricClient).ToNot(BeNil())
+			Expect(pc.smClient.Name()).To(Equal("test-fabric"))
 		})
 
-		It("fabricClient is nil when plugin does not implement FabricClient", func() {
+		It("nil fabricClient is preserved for legacy plugins", func() {
 			sm := &mockSMClient{name: "legacy-sm"}
 
-			d := &daemon{
-				smClient:          sm,
-				fabricClient:      nil,
-				guidPodNetworkMap: make(map[string]string),
-			}
-
-			Expect(d.fabricClient).To(BeNil())
+			pc := newPartitionController(nil, sm, nil, nil)
+			Expect(pc.fabricClient).To(BeNil())
+			Expect(pc.smClient.Name()).To(Equal("legacy-sm"))
 		})
 	})
 
@@ -1058,7 +1074,7 @@ var _ = Describe("Daemon", func() {
 
 		BeforeEach(func() {
 			mockK8sClient = &k8sMocks.Client{}
-			testDaemon.kubeClient = mockK8sClient
+			testPodCtrl.kubeClient = mockK8sClient
 		})
 
 		It("returns a non-nil error when SetAnnotationsOnPod fails", func() {
@@ -1087,7 +1103,7 @@ var _ = Describe("Daemon", func() {
 			).Return(kerrors.NewNotFound(gr, "p1"))
 
 			var removed []net.HardwareAddr
-			err := testDaemon.updatePodNetworkAnnotation(pi, &removed, "0x1234")
+			err := testPodCtrl.updatePodNetworkAnnotation(pi, &removed, "0x1234")
 
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("ns1/p1"))
@@ -1113,7 +1129,7 @@ var _ = Describe("Daemon", func() {
 			).Return(kerrors.NewNotFound(gr, "p1"))
 
 			var removed []net.HardwareAddr
-			err := testDaemon.updatePodNetworkAnnotation(pi, &removed, "")
+			err := testPodCtrl.updatePodNetworkAnnotation(pi, &removed, "")
 
 			Expect(err).To(HaveOccurred())
 			Expect(removed).To(BeEmpty())
@@ -1151,7 +1167,7 @@ var _ = Describe("Daemon", func() {
 					{Device: "mlx5_0", GUID: net.HardwareAddr{0x02, 0, 0, 0, 0, 0, 0, 0x01}},
 				},
 			}
-			d := &daemon{smClient: fabric, fabricClient: fabric, kubeClient: mockK8sClient}
+			d := &partitionController{smClient: fabric, fabricClient: fabric, kubeClient: mockK8sClient}
 			addMap := utils.NewSynchronizedMap()
 			addMap.Set("ns1_ib-net", []*kapi.Pod{newPartitionPod()})
 
@@ -1167,6 +1183,43 @@ var _ = Describe("Daemon", func() {
 			Expect(fabric.getDevicesCalls).To(Equal(1))
 		})
 
+		It("does not bind GUIDs when the PKey annotation write fails", func() {
+			useFastBackoff()
+			fabric := &mockFabricClient{
+				mockSMClient:      mockSMClient{name: "test-fabric"},
+				partitionReady:    true,
+				partitionReadyKey: "0x5ac",
+				nodeIBDevices: []plugins.IBDeviceGUID{
+					{Device: "mlx5_0", GUID: net.HardwareAddr{0x02, 0, 0, 0, 0, 0, 0, 0x0a}},
+				},
+			}
+			// Managed NAD with no PKey annotation yet, so ProcessAddIfManaged must
+			// persist the pkey before binding GUIDs; the annotation write then fails.
+			nad := &v1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "ib-net", Namespace: "ns1"},
+				Spec:       v1.NetworkAttachmentDefinitionSpec{Config: `{"type":"ib-sriov","ibKubernetesEnabled":true}`},
+			}
+			mockK8sClient.On("GetNetworkAttachmentDefinition", "ns1", "ib-net").Return(nad.DeepCopy(), nil)
+			mockK8sClient.On("UpdateNetworkAttachmentDefinition", testifyMock.Anything).
+				Return(fmt.Errorf("apiserver rejected update"))
+			d := &partitionController{smClient: fabric, fabricClient: fabric, kubeClient: mockK8sClient}
+			d.cacheNAD("ns1_ib-net", nad)
+
+			addMap := utils.NewSynchronizedMap()
+			addMap.Set("ns1_ib-net", []*kapi.Pod{newPartitionPod()})
+
+			handled := d.ProcessAddIfManaged("ns1_ib-net", "ib-net",
+				addMap.Items["ns1_ib-net"].([]*kapi.Pod),
+				networksMap{theMap: map[types.UID][]*v1.NetworkSelectionElement{}}, addMap)
+
+			Expect(handled).To(BeTrue(), "managed network: caller must not fall through to the legacy path")
+			Expect(fabric.addGuidsCallCount).To(Equal(0),
+				"must not bind GUIDs before the PKey annotation is persisted")
+			Expect(fabric.getDevicesCalls).To(Equal(0))
+			_, stillQueued := addMap.Get("ns1_ib-net")
+			Expect(stillQueued).To(BeTrue(), "entry retained so the next tick retries")
+		})
+
 		It("removes the add queue entry after GUID add and pod annotation succeed", func() {
 			pod := newPartitionPod()
 			fabric := &mockFabricClient{
@@ -1176,7 +1229,8 @@ var _ = Describe("Daemon", func() {
 				},
 			}
 			mockK8sClient.On("SetAnnotationsOnPod", pod, testifyMock.Anything).Return(nil)
-			d := &daemon{smClient: fabric, fabricClient: fabric, kubeClient: mockK8sClient}
+			d := &partitionController{smClient: fabric, fabricClient: fabric, kubeClient: mockK8sClient}
+			d.updatePodAnnotation = (&podController{kubeClient: mockK8sClient}).updatePodNetworkAnnotation
 			addMap := utils.NewSynchronizedMap()
 			addMap.Set("ns1_ib-net", []*kapi.Pod{pod})
 
@@ -1205,7 +1259,8 @@ var _ = Describe("Daemon", func() {
 			gr := schema.GroupResource{Resource: "pods"}
 			mockK8sClient.On("SetAnnotationsOnPod", pod, testifyMock.Anything).
 				Return(kerrors.NewNotFound(gr, "p1"))
-			d := &daemon{smClient: fabric, fabricClient: fabric, kubeClient: mockK8sClient}
+			d := &partitionController{smClient: fabric, fabricClient: fabric, kubeClient: mockK8sClient}
+			d.updatePodAnnotation = (&podController{kubeClient: mockK8sClient}).updatePodNetworkAnnotation
 			addMap := utils.NewSynchronizedMap()
 			addMap.Set("ns1_ib-net", []*kapi.Pod{pod})
 
@@ -1222,7 +1277,7 @@ var _ = Describe("Daemon", func() {
 		It("returns without panicking when FabricClient is absent", func() {
 			addMap := utils.NewSynchronizedMap()
 			addMap.Set("ns1_ib-net", []*kapi.Pod{newPartitionPod()})
-			d := &daemon{smClient: &mockSMClient{name: "legacy-sm"}}
+			d := &partitionController{smClient: &mockSMClient{name: "legacy-sm"}}
 
 			Expect(func() {
 				d.processPartitionPods(
@@ -1235,9 +1290,8 @@ var _ = Describe("Daemon", func() {
 	})
 
 	Context("partition-aware pod deletion", func() {
-		It("returns without panicking when FabricClient is absent", func() {
-			d := &daemon{smClient: &mockSMClient{name: "legacy-sm"}}
-			d.cacheNAD("ns1_ib-net", &v1.NetworkAttachmentDefinition{
+		newManagedNAD := func() *v1.NetworkAttachmentDefinition {
+			return &v1.NetworkAttachmentDefinition{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "ib-net",
 					Namespace: "ns1",
@@ -1248,14 +1302,19 @@ var _ = Describe("Daemon", func() {
 				Spec: v1.NetworkAttachmentDefinitionSpec{
 					Config: `{"type":"ib-sriov","ibKubernetesEnabled":true}`,
 				},
-			})
+			}
+		}
 
-			Expect(func() {
-				d.deletePartitionPods("ns1_ib-net", []*kapi.Pod{{
-					ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "ns1"},
-					Spec:       kapi.PodSpec{NodeName: "node-1"},
-				}})
-			}).ToNot(Panic())
+		It("returns nil and no panic when FabricClient is absent", func() {
+			d := &partitionController{smClient: &mockSMClient{name: "legacy-sm"}}
+			d.cacheNAD("ns1_ib-net", newManagedNAD())
+
+			err := d.DeletePartitionPods("ns1_ib-net", []*kapi.Pod{{
+				ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "ns1"},
+				Spec:       kapi.PodSpec{NodeName: "node-1"},
+			}})
+
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("removes node PF GUIDs from the partition", func() {
@@ -1266,29 +1325,160 @@ var _ = Describe("Daemon", func() {
 					{Device: "mlx5_1", GUID: net.HardwareAddr{0x02, 0, 0, 0, 0, 0, 0, 0x05}},
 				},
 			}
-			d := &daemon{smClient: fabric, fabricClient: fabric}
-			d.cacheNAD("ns1_ib-net", &v1.NetworkAttachmentDefinition{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "ib-net",
-					Namespace: "ns1",
-					Annotations: map[string]string{
-						utils.PartitionKeyAnnotation: "0x5ac",
-					},
-				},
-				Spec: v1.NetworkAttachmentDefinitionSpec{
-					Config: `{"type":"ib-sriov","ibKubernetesEnabled":true}`,
-				},
-			})
+			d := &partitionController{smClient: fabric, fabricClient: fabric}
+			d.cacheNAD("ns1_ib-net", newManagedNAD())
 
-			d.deletePartitionPods("ns1_ib-net", []*kapi.Pod{{
+			err := d.DeletePartitionPods("ns1_ib-net", []*kapi.Pod{{
 				ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "ns1"},
 				Spec:       kapi.PodSpec{NodeName: "node-1"},
 			}})
 
+			Expect(err).ToNot(HaveOccurred())
 			Expect(fabric.requestedNodeNames).To(Equal([]string{"node-1"}))
 			Expect(fabric.removeGuidsCallCount).To(Equal(1))
 			Expect(fabric.removeGuidsPKey).To(Equal(0x5ac))
 			Expect(fabric.removedGuids).To(HaveLen(2))
+		})
+
+		It("returns first error when RemoveGuidsFromPKey fails", func() {
+			fabric := &mockFabricClient{
+				mockSMClient: mockSMClient{
+					name:                     "test-fabric",
+					removeGuidsFromPKeyError: fmt.Errorf("backend gRPC not connected"),
+				},
+				nodeIBDevices: []plugins.IBDeviceGUID{
+					{Device: "mlx5_0", GUID: net.HardwareAddr{0x02, 0, 0, 0, 0, 0, 0, 0x07}},
+				},
+			}
+			d := &partitionController{smClient: fabric, fabricClient: fabric}
+			d.cacheNAD("ns1_ib-net", newManagedNAD())
+
+			err := d.DeletePartitionPods("ns1_ib-net", []*kapi.Pod{{
+				ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "ns1"},
+				Spec:       kapi.PodSpec{NodeName: "node-1"},
+			}})
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("backend gRPC not connected"))
+			Expect(fabric.removeGuidsCallCount).To(Equal(1))
+		})
+
+		It("returns first error when GetNodeIBDevices fails", func() {
+			fabric := &mockFabricClient{
+				mockSMClient:     mockSMClient{name: "test-fabric"},
+				nodeIBDevicesErr: fmt.Errorf("node unreachable"),
+			}
+			d := &partitionController{smClient: fabric, fabricClient: fabric}
+			d.cacheNAD("ns1_ib-net", newManagedNAD())
+
+			err := d.DeletePartitionPods("ns1_ib-net", []*kapi.Pod{{
+				ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "ns1"},
+				Spec:       kapi.PodSpec{NodeName: "node-1"},
+			}})
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("node unreachable"))
+			Expect(fabric.removeGuidsCallCount).To(Equal(0))
+		})
+
+		// Proves the gate in podController.DeletePeriodicUpdate: when
+		// DeletePartitionPods returns a non-nil error the delete-queue entry
+		// MUST stay so the next periodic tick retries the detach. Dropping it
+		// here would leave the node/instance attached to a partition we
+		// already asked the backend to release.
+		It("DeletePeriodicUpdate retains delete-queue entry when detach fails", func() {
+			fabric := &mockFabricClient{
+				mockSMClient: mockSMClient{
+					name:                     "test-fabric",
+					removeGuidsFromPKeyError: fmt.Errorf("backend gRPC not connected"),
+				},
+				nodeIBDevices: []plugins.IBDeviceGUID{
+					{Device: "mlx5_0", GUID: net.HardwareAddr{0x02, 0, 0, 0, 0, 0, 0, 0x08}},
+				},
+			}
+			partitionCtrl := &partitionController{smClient: fabric, fabricClient: fabric}
+			partitionCtrl.cacheNAD("ns1_ib-net", newManagedNAD())
+
+			deleteMap := utils.NewSynchronizedMap()
+			pod := &kapi.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "p1", Namespace: "ns1",
+					Annotations: map[string]string{
+						v1.NetworkAttachmentAnnot: `[{"name":"ib-net","namespace":"ns1"}]`,
+					},
+				},
+				Spec: kapi.PodSpec{NodeName: "node-1"},
+			}
+			deleteMap.Set("ns1_ib-net", []*kapi.Pod{pod})
+
+			podCtrl := &podController{
+				smClient:          fabric,
+				guidPool:          guidPool,
+				guidPodNetworkMap: make(map[string]string),
+				podWatcher: &stubWatcher{handler: &stubEventHandler{
+					addMap:    utils.NewSynchronizedMap(),
+					deleteMap: deleteMap,
+				}},
+				partition: partitionCtrl,
+			}
+
+			podCtrl.DeletePeriodicUpdate()
+
+			_, stillQueued := deleteMap.Get("ns1_ib-net")
+			Expect(stillQueued).To(BeTrue(),
+				"delete-queue entry must survive a failed partition detach so the next tick retries")
+			Expect(fabric.removeGuidsCallCount).To(Equal(1),
+				"detach must have been attempted exactly once this pass")
+		})
+
+		It("warms a cold cache before routing a partition-managed delete", func() {
+			// The first delete tick after daemon start / leader failover can beat
+			// the NAD informer, leaving the cache cold. Warming it before
+			// IsPartitionManaged keeps the managed detach from being misrouted to
+			// the legacy path, which finds no pool GUID for a PF-mode pod and
+			// would dequeue the entry without detaching.
+			fabric := &mockFabricClient{
+				mockSMClient: mockSMClient{name: "test-fabric"},
+				nodeIBDevices: []plugins.IBDeviceGUID{
+					{Device: "mlx5_0", GUID: net.HardwareAddr{0x02, 0, 0, 0, 0, 0, 0, 0x09}},
+				},
+			}
+			mockK8sClient := &k8sMocks.Client{}
+			// Cache intentionally left cold; the NAD is only reachable via the API.
+			mockK8sClient.On("GetNetworkAttachmentDefinition", "ns1", "ib-net").
+				Return(newManagedNAD(), nil)
+			partitionCtrl := &partitionController{smClient: fabric, fabricClient: fabric, kubeClient: mockK8sClient}
+
+			deleteMap := utils.NewSynchronizedMap()
+			pod := &kapi.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "p1", Namespace: "ns1",
+					Annotations: map[string]string{
+						v1.NetworkAttachmentAnnot: `[{"name":"ib-net","namespace":"ns1"}]`,
+					},
+				},
+				Spec: kapi.PodSpec{NodeName: "node-1"},
+			}
+			deleteMap.Set("ns1_ib-net", []*kapi.Pod{pod})
+
+			podCtrl := &podController{
+				smClient:          fabric,
+				guidPool:          guidPool,
+				guidPodNetworkMap: make(map[string]string),
+				podWatcher: &stubWatcher{handler: &stubEventHandler{
+					addMap:    utils.NewSynchronizedMap(),
+					deleteMap: deleteMap,
+				}},
+				partition: partitionCtrl,
+			}
+
+			podCtrl.DeletePeriodicUpdate()
+
+			Expect(fabric.removeGuidsCallCount).To(Equal(1),
+				"managed detach must run even when the cache started cold")
+			_, stillQueued := deleteMap.Get("ns1_ib-net")
+			Expect(stillQueued).To(BeFalse(),
+				"a successful detach dequeues the entry")
 		})
 	})
 
@@ -1312,7 +1502,7 @@ var _ = Describe("Daemon", func() {
 			}
 			nad := newPartitionNAD()
 			nad.Annotations = map[string]string{utils.PartitionKeyAnnotation: "0x5ac"}
-			d := &daemon{fabricClient: fabric}
+			d := &partitionController{fabricClient: fabric}
 
 			err := d.setupPartitionForNAD(nad)
 
@@ -1324,7 +1514,7 @@ var _ = Describe("Daemon", func() {
 			fabric := &mockFabricClient{mockSMClient: mockSMClient{name: "test-fabric"}}
 			nad := newPartitionNAD()
 			nad.Spec.Config = `{"type":"sriov","ibKubernetesEnabled":true}`
-			d := &daemon{fabricClient: fabric}
+			d := &partitionController{fabricClient: fabric}
 
 			err := d.setupPartitionForNAD(nad)
 
@@ -1336,7 +1526,7 @@ var _ = Describe("Daemon", func() {
 			fabric := &mockFabricClient{mockSMClient: mockSMClient{name: "test-fabric"}}
 			nad := newPartitionNAD()
 			nad.Spec.Config = `{"type":"ib-sriov","ibKubernetesEnabled":false}`
-			d := &daemon{fabricClient: fabric}
+			d := &partitionController{fabricClient: fabric}
 
 			err := d.setupPartitionForNAD(nad)
 
@@ -1359,7 +1549,7 @@ var _ = Describe("Daemon", func() {
 				Run(func(args testifyMock.Arguments) {
 					updatedNAD = args.Get(0).(*v1.NetworkAttachmentDefinition)
 				}).Return(nil)
-			d := &daemon{fabricClient: fabric, kubeClient: mockK8sClient}
+			d := &partitionController{fabricClient: fabric, kubeClient: mockK8sClient}
 
 			err := d.setupPartitionForNAD(nad)
 
@@ -1368,6 +1558,81 @@ var _ = Describe("Daemon", func() {
 			Expect(updatedNAD).ToNot(BeNil())
 			Expect(updatedNAD.Annotations[utils.PartitionKeyAnnotation]).To(Equal("0x5ac"))
 			Expect(updatedNAD.Finalizers).To(ContainElement(utils.PartitionNADFinalizer))
+		})
+
+		It("skips partition creation when the NAD is already terminating", func() {
+			fabric := &mockFabricClient{
+				mockSMClient:       mockSMClient{name: "test-fabric"},
+				createPartitionKey: "0x5ac",
+			}
+			mockK8sClient := &k8sMocks.Client{}
+			nad := newPartitionNAD()
+			terminating := nad.DeepCopy()
+			now := metav1.NewTime(time.Now())
+			terminating.DeletionTimestamp = &now
+			mockK8sClient.On("GetNetworkAttachmentDefinition", "ns1", "ib-net").
+				Return(terminating, nil)
+			d := &partitionController{fabricClient: fabric, kubeClient: mockK8sClient}
+
+			err := d.setupPartitionForNAD(nad)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fabric.createPartitionCalls).To(Equal(0),
+				"must not create a partition for a NAD that is already terminating")
+		})
+
+		It("rolls back the created partition when the NAD races into terminating during setup", func() {
+			useFastBackoff()
+			fabric := &mockFabricClient{
+				mockSMClient:       mockSMClient{name: "test-fabric"},
+				createPartitionKey: "0x5ac",
+			}
+			mockK8sClient := &k8sMocks.Client{}
+			nad := newPartitionNAD()
+			terminating := nad.DeepCopy()
+			now := metav1.NewTime(time.Now())
+			terminating.DeletionTimestamp = &now
+
+			// Pre-create check sees a live NAD; the finalizer write then fails
+			// (k8s rejects finalizers on a deleting object); the rollback re-check
+			// sees the NAD now terminating and deletes the orphaned partition.
+			getPre := mockK8sClient.On("GetNetworkAttachmentDefinition", "ns1", "ib-net").
+				Return(nad.DeepCopy(), nil).Once()
+			getWrite := mockK8sClient.On("GetNetworkAttachmentDefinition", "ns1", "ib-net").
+				Return(nad.DeepCopy(), nil).Once().NotBefore(getPre)
+			update := mockK8sClient.On("UpdateNetworkAttachmentDefinition", testifyMock.Anything).
+				Return(fmt.Errorf("forbidden: no new finalizers can be added if the object is being deleted")).
+				Once().NotBefore(getWrite)
+			mockK8sClient.On("GetNetworkAttachmentDefinition", "ns1", "ib-net").
+				Return(terminating, nil).Once().NotBefore(update)
+			d := &partitionController{fabricClient: fabric, kubeClient: mockK8sClient}
+
+			err := d.setupPartitionForNAD(nad)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fabric.createPartitionCalls).To(Equal(1))
+			Expect(fabric.deletedPartitionNames).To(Equal([]string{"ns1_ib-net"}),
+				"a partition created for a NAD that raced into terminating must be rolled back")
+		})
+
+		It("skips updating a NAD that already has the same PKey and finalizer", func() {
+			useFastBackoff()
+			mockK8sClient := &k8sMocks.Client{}
+			nad := newPartitionNAD()
+			nad.Annotations = map[string]string{utils.PartitionKeyAnnotation: "0x5ac"}
+			nad.Finalizers = []string{utils.PartitionNADFinalizer}
+			mockK8sClient.On("GetNetworkAttachmentDefinition", "ns1", "ib-net").
+				Return(nad.DeepCopy(), nil).Once()
+			d := &partitionController{kubeClient: mockK8sClient}
+
+			err := d.updateNADPartitionKey("ns1_ib-net", "0x5ac")
+
+			Expect(err).ToNot(HaveOccurred())
+			mockK8sClient.AssertNumberOfCalls(GinkgoT(), "UpdateNetworkAttachmentDefinition", 0)
+			cached, ok := d.nadCache.Load("ns1_ib-net")
+			Expect(ok).To(BeTrue())
+			Expect(cached.(*v1.NetworkAttachmentDefinition).Annotations[utils.PartitionKeyAnnotation]).
+				To(Equal("0x5ac"))
 		})
 
 		It("deletes the backend partition and removes the NAD finalizer", func() {
@@ -1384,7 +1649,7 @@ var _ = Describe("Daemon", func() {
 				Run(func(args testifyMock.Arguments) {
 					updatedNAD = args.Get(0).(*v1.NetworkAttachmentDefinition)
 				}).Return(nil)
-			d := &daemon{fabricClient: fabric, kubeClient: mockK8sClient}
+			d := &partitionController{fabricClient: fabric, kubeClient: mockK8sClient}
 
 			err := d.handleNADDeletion(nad)
 
@@ -1414,7 +1679,7 @@ var _ = Describe("Daemon", func() {
 				Return(secondFreshNAD, nil).Once().NotBefore(update1)
 			mockK8sClient.On("UpdateNetworkAttachmentDefinition", testifyMock.Anything).
 				Return(nil).Once().NotBefore(get2)
-			d := &daemon{kubeClient: mockK8sClient}
+			d := &partitionController{kubeClient: mockK8sClient}
 
 			err := d.removeNADFinalizer(nad, utils.PartitionNADFinalizer)
 
@@ -1423,12 +1688,116 @@ var _ = Describe("Daemon", func() {
 		})
 	})
 
-	Context("getCachedNAD error type preservation", func() {
-		var mockK8sClient *k8sMocks.Client
+	Context("processNADResults handleNADDeletion gating", func() {
+		// Proves the A3 invariant from PR #228 review: a NAD entering Terminating
+		// without our PartitionNADFinalizer must NOT reach DeleteIBPartition.
+		// The finalizer is the only signal that *we* created the partition;
+		// without it the partition belongs to someone else (or never existed).
+
+		It("does not call DeleteIBPartition when the NAD lacks our finalizer", func() {
+			fabric := &mockFabricClient{mockSMClient: mockSMClient{name: "test-fabric"}}
+			pc := newPartitionController(fabric, fabric, nil, nil)
+
+			now := metav1.NewTime(time.Now())
+			nad := &v1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "ib-net",
+					Namespace:         "ns1",
+					DeletionTimestamp: &now,
+					// No finalizers — someone else's NAD, we never owned it.
+				},
+				Spec: v1.NetworkAttachmentDefinitionSpec{
+					Config: `{"type":"ib-sriov","ibKubernetesEnabled":true}`,
+				},
+			}
+
+			added := utils.NewSynchronizedMap()
+			deleted := utils.NewSynchronizedMap()
+			deleted.Set("ns1_ib-net", nad)
+
+			pc.processNADResults(added, deleted)
+
+			Expect(fabric.deletePartitionCalls).To(Equal(0),
+				"DeleteIBPartition must not be called for a NAD without PartitionNADFinalizer")
+			_, stillQueued := deleted.Get("ns1_ib-net")
+			Expect(stillQueued).To(BeFalse(),
+				"queue entry should be cleared so we don't loop on a NAD we don't own")
+		})
+
+		It("drains deletedNADs queue even when FabricClient is absent (no memory leak for legacy plugins)", func() {
+			// Legacy plugins (UFM/noop) have no FabricClient. The deletedNADs
+			// queue must still be drained so nadCache + partitionManagedCache
+			// don't grow unbounded across NAD-delete events.
+			pc := newPartitionController(nil, &mockSMClient{name: "legacy-sm"}, nil, nil)
+			pc.cacheNAD("ns1_ib-net", &v1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "ib-net", Namespace: "ns1"},
+				Spec: v1.NetworkAttachmentDefinitionSpec{
+					Config: `{"type":"ib-sriov","ibKubernetesEnabled":true}`,
+				},
+			})
+
+			added := utils.NewSynchronizedMap()
+			deleted := utils.NewSynchronizedMap()
+			deleted.Set("ns1_ib-net", &v1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "ib-net", Namespace: "ns1"},
+				Spec: v1.NetworkAttachmentDefinitionSpec{
+					Config: `{"type":"ib-sriov","ibKubernetesEnabled":true}`,
+				},
+			})
+
+			pc.processNADResults(added, deleted)
+
+			_, stillQueued := deleted.Get("ns1_ib-net")
+			Expect(stillQueued).To(BeFalse(),
+				"deletedNADs queue must drain even when fabricClient is nil")
+			_, stillCached := pc.nadCache.Load("ns1_ib-net")
+			Expect(stillCached).To(BeFalse(),
+				"nadCache entry must be removed alongside queue drain")
+		})
+
+		It("calls DeleteIBPartition when the NAD carries our finalizer", func() {
+			useFastBackoff()
+			fabric := &mockFabricClient{mockSMClient: mockSMClient{name: "test-fabric"}}
+			mockK8sClient := &k8sMocks.Client{}
+			pc := newPartitionController(fabric, fabric, mockK8sClient, nil)
+
+			now := metav1.NewTime(time.Now())
+			nad := &v1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "ib-net",
+					Namespace:         "ns1",
+					DeletionTimestamp: &now,
+					Finalizers:        []string{utils.PartitionNADFinalizer},
+				},
+				Spec: v1.NetworkAttachmentDefinitionSpec{
+					Config: `{"type":"ib-sriov","ibKubernetesEnabled":true}`,
+				},
+			}
+			mockK8sClient.On("GetNetworkAttachmentDefinition", "ns1", "ib-net").
+				Return(nad.DeepCopy(), nil)
+			mockK8sClient.On("UpdateNetworkAttachmentDefinition", testifyMock.Anything).
+				Return(nil)
+
+			added := utils.NewSynchronizedMap()
+			deleted := utils.NewSynchronizedMap()
+			deleted.Set("ns1_ib-net", nad)
+
+			pc.processNADResults(added, deleted)
+
+			Expect(fabric.deletePartitionCalls).To(Equal(1))
+			Expect(fabric.deletedPartitionNames).To(Equal([]string{"ns1_ib-net"}))
+		})
+	})
+
+	Context("GetCachedNAD error type preservation", func() {
+		var (
+			mockK8sClient *k8sMocks.Client
+			partitionCtrl *partitionController
+		)
 
 		BeforeEach(func() {
 			mockK8sClient = &k8sMocks.Client{}
-			testDaemon.kubeClient = mockK8sClient
+			partitionCtrl = &partitionController{kubeClient: mockK8sClient}
 		})
 
 		It("returns an error that satisfies kerrors.IsNotFound when NAD missing", func() {
@@ -1439,7 +1808,7 @@ var _ = Describe("Daemon", func() {
 				"GetNetworkAttachmentDefinition", "ns1", "n1",
 			).Return(nil, notFoundErr)
 
-			_, err := testDaemon.getCachedNAD("ns1_n1")
+			_, err := partitionCtrl.GetCachedNAD("ns1_n1")
 
 			Expect(err).To(HaveOccurred())
 			Expect(kerrors.IsNotFound(err)).To(BeTrue(),

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -1732,6 +1732,49 @@ var _ = Describe("Daemon", func() {
 			Expect(fabric.deletePartitionCalls).To(Equal(0))
 		})
 
+		It("refreshes the NAD cache on the already-finalized fast path", func() {
+			useFastBackoff()
+			// A later add tick can re-cache the original no-finalizer snapshot
+			// after the finalizer was already persisted. The delete path prefers
+			// the cache, so the fast path must refresh it — otherwise the stale
+			// entry hides the finalizer and the partition is orphaned.
+			mockK8sClient := &k8sMocks.Client{}
+			stale := newPartitionNAD() // cached without the finalizer
+			finalized := newPartitionNAD()
+			finalized.Finalizers = []string{utils.PartitionNADFinalizer}
+			mockK8sClient.On("GetNetworkAttachmentDefinition", "ns1", "ib-net").
+				Return(finalized.DeepCopy(), nil)
+			d := &partitionController{kubeClient: mockK8sClient}
+			d.cacheNAD("ns1_ib-net", stale)
+
+			Expect(d.addNADFinalizer(stale)).To(Succeed())
+
+			cached, err := d.GetCachedNAD("ns1_ib-net")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hasPartitionFinalizer(cached)).To(BeTrue(),
+				"already-finalized fast path must refresh the cache with the finalized NAD")
+		})
+
+		It("does not let a stale no-finalizer add snapshot regress a finalized cache entry", func() {
+			// fabricClient nil isolates the add-loop cache guard: a stale add
+			// snapshot must not clobber a cache entry that already carries the
+			// finalizer, or the delete loop would skip cleanup and orphan the partition.
+			finalized := newPartitionNAD()
+			finalized.Finalizers = []string{utils.PartitionNADFinalizer}
+			d := &partitionController{}
+			d.cacheNAD("ns1_ib-net", finalized)
+
+			added := utils.NewSynchronizedMap()
+			added.Set("ns1_ib-net", newPartitionNAD()) // same network, no finalizer
+
+			d.processNADResults(added, utils.NewSynchronizedMap())
+
+			cachedVal, ok := d.nadCache.Load("ns1_ib-net")
+			Expect(ok).To(BeTrue())
+			Expect(hasPartitionFinalizer(cachedVal.(*v1.NetworkAttachmentDefinition))).To(BeTrue(),
+				"stale add snapshot must not regress a finalized cache entry")
+		})
+
 		It("skips updating a NAD that already has the same PKey and finalizer", func() {
 			useFastBackoff()
 			mockK8sClient := &k8sMocks.Client{}

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -112,6 +112,7 @@ type mockFabricClient struct {
 	createPartitionError  error
 	createPartitionCalls  int
 	createdPartitionNames []string
+	createPartitionHook   func()
 
 	// DeleteIBPartition
 	deletePartitionError  error
@@ -133,6 +134,9 @@ type mockFabricClient struct {
 }
 
 func (m *mockFabricClient) CreateIBPartition(name string) (string, error) {
+	if m.createPartitionHook != nil {
+		m.createPartitionHook()
+	}
 	m.createPartitionCalls++
 	m.createdPartitionNames = append(m.createdPartitionNames, name)
 	return m.createPartitionKey, m.createPartitionError
@@ -170,7 +174,7 @@ type stubWatcher struct {
 	handler resEventHandler.ResourceEventHandler
 }
 
-func (s *stubWatcher) RunBackground() watcher.StopFunc            { return func() {} }
+func (s *stubWatcher) RunBackground() watcher.StopFunc                  { return func() {} }
 func (s *stubWatcher) GetHandler() resEventHandler.ResourceEventHandler { return s.handler }
 
 type stubEventHandler struct {
@@ -1248,7 +1252,7 @@ var _ = Describe("Daemon", func() {
 			Expect(pod.Annotations[v1.NetworkAttachmentAnnot]).To(ContainSubstring(utils.ConfiguredInfiniBandPod))
 		})
 
-		It("keeps the add queue when PF-mode annotation update fails", func() {
+		It("rolls back PF GUIDs when the pod annotation update fails", func() {
 			pod := newPartitionPod()
 			fabric := &mockFabricClient{
 				mockSMClient: mockSMClient{name: "test-fabric"},
@@ -1272,6 +1276,73 @@ var _ = Describe("Daemon", func() {
 
 			_, exists := addMap.Get("ns1_ib-net")
 			Expect(exists).To(BeTrue())
+			Expect(fabric.removeGuidsCallCount).To(Equal(1))
+			Expect(fabric.removeGuidsPKey).To(Equal(0x5ac))
+			Expect(fabric.removedGuids).To(Equal(fabric.addGuids))
+		})
+
+		It("stops annotation writes after the first failure before rolling back PF GUIDs", func() {
+			pod := newPartitionPod()
+			pod.Annotations[v1.NetworkAttachmentAnnot] = `[
+				{"name":"ib-net","namespace":"ns1","interface":"net1"},
+				{"name":"ib-net","namespace":"ns1","interface":"net2"}
+			]`
+			fabric := &mockFabricClient{
+				mockSMClient: mockSMClient{name: "test-fabric"},
+				nodeIBDevices: []plugins.IBDeviceGUID{
+					{Device: "mlx5_0", GUID: net.HardwareAddr{0x02, 0, 0, 0, 0, 0, 0, 0x0c}},
+				},
+			}
+			annotationCalls := 0
+			gr := schema.GroupResource{Resource: "pods"}
+			mockK8sClient.On("SetAnnotationsOnPod", pod, testifyMock.Anything).
+				Return(func(_ *kapi.Pod, _ map[string]string) error {
+					annotationCalls++
+					if annotationCalls == 1 {
+						return kerrors.NewNotFound(gr, "p1")
+					}
+					return nil
+				})
+			d := &partitionController{smClient: fabric, fabricClient: fabric, kubeClient: mockK8sClient}
+			d.updatePodAnnotation = (&podController{kubeClient: mockK8sClient}).updatePodNetworkAnnotation
+			addMap := utils.NewSynchronizedMap()
+			addMap.Set("ns1_ib-net", []*kapi.Pod{pod})
+
+			d.processPartitionPods(
+				[]*kapi.Pod{pod}, "ib-net", "0x5ac",
+				networksMap{theMap: map[types.UID][]*v1.NetworkSelectionElement{}},
+				addMap, "ns1_ib-net",
+			)
+
+			Expect(annotationCalls).To(Equal(1))
+			Expect(fabric.removeGuidsCallCount).To(Equal(1))
+			_, exists := addMap.Get("ns1_ib-net")
+			Expect(exists).To(BeTrue())
+		})
+
+		It("rolls back PF GUIDs when the pod annotation hook is missing", func() {
+			pod := newPartitionPod()
+			fabric := &mockFabricClient{
+				mockSMClient: mockSMClient{name: "test-fabric"},
+				nodeIBDevices: []plugins.IBDeviceGUID{
+					{Device: "mlx5_0", GUID: net.HardwareAddr{0x02, 0, 0, 0, 0, 0, 0, 0x0b}},
+				},
+			}
+			d := &partitionController{smClient: fabric, fabricClient: fabric, kubeClient: mockK8sClient}
+			addMap := utils.NewSynchronizedMap()
+			addMap.Set("ns1_ib-net", []*kapi.Pod{pod})
+
+			d.processPartitionPods(
+				[]*kapi.Pod{pod}, "ib-net", "0x5ac",
+				networksMap{theMap: map[types.UID][]*v1.NetworkSelectionElement{}},
+				addMap, "ns1_ib-net",
+			)
+
+			_, exists := addMap.Get("ns1_ib-net")
+			Expect(exists).To(BeTrue())
+			Expect(fabric.removeGuidsCallCount).To(Equal(1))
+			Expect(fabric.removeGuidsPKey).To(Equal(0x5ac))
+			Expect(fabric.removedGuids).To(Equal(fabric.addGuids))
 		})
 
 		It("returns without panicking when FabricClient is absent", func() {
@@ -1378,6 +1449,25 @@ var _ = Describe("Daemon", func() {
 
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("node unreachable"))
+			Expect(fabric.removeGuidsCallCount).To(Equal(0))
+		})
+
+		It("retains the entry when a node reports no IB devices (transient empty inventory)", func() {
+			fabric := &mockFabricClient{
+				mockSMClient:  mockSMClient{name: "test-fabric"},
+				nodeIBDevices: []plugins.IBDeviceGUID{}, // empty inventory, no error
+			}
+			d := &partitionController{smClient: fabric, fabricClient: fabric}
+			d.cacheNAD("ns1_ib-net", newManagedNAD())
+
+			err := d.DeletePartitionPods("ns1_ib-net", []*kapi.Pod{{
+				ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "ns1"},
+				Spec:       kapi.PodSpec{NodeName: "node-1"},
+			}})
+
+			// Non-nil error so DeletePeriodicUpdate keeps the entry for retry;
+			// nothing was detached, so RemoveGuidsFromPKey must not be called.
+			Expect(err).To(HaveOccurred())
 			Expect(fabric.removeGuidsCallCount).To(Equal(0))
 		})
 
@@ -1560,6 +1650,40 @@ var _ = Describe("Daemon", func() {
 			Expect(updatedNAD.Finalizers).To(ContainElement(utils.PartitionNADFinalizer))
 		})
 
+		It("adds the finalizer before creating the backend partition", func() {
+			useFastBackoff()
+			events := []string{}
+			apiNAD := newPartitionNAD()
+			fabric := &mockFabricClient{
+				mockSMClient:       mockSMClient{name: "test-fabric"},
+				createPartitionKey: "0x5ac",
+				createPartitionHook: func() {
+					events = append(events, "create")
+				},
+			}
+			mockK8sClient := &k8sMocks.Client{}
+			mockK8sClient.On("GetNetworkAttachmentDefinition", "ns1", "ib-net").
+				Return(func(_, _ string) (*v1.NetworkAttachmentDefinition, error) {
+					return apiNAD.DeepCopy(), nil
+				})
+			mockK8sClient.On("UpdateNetworkAttachmentDefinition", testifyMock.Anything).
+				Run(func(args testifyMock.Arguments) {
+					apiNAD = args.Get(0).(*v1.NetworkAttachmentDefinition).DeepCopy()
+					if apiNAD.Annotations != nil &&
+						apiNAD.Annotations[utils.PartitionKeyAnnotation] != "" {
+						events = append(events, "pkey")
+						return
+					}
+					events = append(events, "finalizer")
+				}).Return(nil)
+			d := &partitionController{fabricClient: fabric, kubeClient: mockK8sClient}
+
+			err := d.setupPartitionForNAD(apiNAD)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(events).To(Equal([]string{"finalizer", "create", "pkey"}))
+		})
+
 		It("skips partition creation when the NAD is already terminating", func() {
 			fabric := &mockFabricClient{
 				mockSMClient:       mockSMClient{name: "test-fabric"},
@@ -1581,38 +1705,31 @@ var _ = Describe("Daemon", func() {
 				"must not create a partition for a NAD that is already terminating")
 		})
 
-		It("rolls back the created partition when the NAD races into terminating during setup", func() {
+		It("retains the finalizer when backend partition creation fails", func() {
 			useFastBackoff()
 			fabric := &mockFabricClient{
-				mockSMClient:       mockSMClient{name: "test-fabric"},
-				createPartitionKey: "0x5ac",
+				mockSMClient:         mockSMClient{name: "test-fabric"},
+				createPartitionError: fmt.Errorf("backend unavailable"),
 			}
 			mockK8sClient := &k8sMocks.Client{}
-			nad := newPartitionNAD()
-			terminating := nad.DeepCopy()
-			now := metav1.NewTime(time.Now())
-			terminating.DeletionTimestamp = &now
-
-			// Pre-create check sees a live NAD; the finalizer write then fails
-			// (k8s rejects finalizers on a deleting object); the rollback re-check
-			// sees the NAD now terminating and deletes the orphaned partition.
-			getPre := mockK8sClient.On("GetNetworkAttachmentDefinition", "ns1", "ib-net").
-				Return(nad.DeepCopy(), nil).Once()
-			getWrite := mockK8sClient.On("GetNetworkAttachmentDefinition", "ns1", "ib-net").
-				Return(nad.DeepCopy(), nil).Once().NotBefore(getPre)
-			update := mockK8sClient.On("UpdateNetworkAttachmentDefinition", testifyMock.Anything).
-				Return(fmt.Errorf("forbidden: no new finalizers can be added if the object is being deleted")).
-				Once().NotBefore(getWrite)
+			apiNAD := newPartitionNAD()
 			mockK8sClient.On("GetNetworkAttachmentDefinition", "ns1", "ib-net").
-				Return(terminating, nil).Once().NotBefore(update)
+				Return(func(_, _ string) (*v1.NetworkAttachmentDefinition, error) {
+					return apiNAD.DeepCopy(), nil
+				})
+			mockK8sClient.On("UpdateNetworkAttachmentDefinition", testifyMock.Anything).
+				Run(func(args testifyMock.Arguments) {
+					apiNAD = args.Get(0).(*v1.NetworkAttachmentDefinition).DeepCopy()
+				}).Return(nil)
 			d := &partitionController{fabricClient: fabric, kubeClient: mockK8sClient}
 
-			err := d.setupPartitionForNAD(nad)
+			err := d.setupPartitionForNAD(apiNAD)
 
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring("failed to create IB partition")))
 			Expect(fabric.createPartitionCalls).To(Equal(1))
-			Expect(fabric.deletedPartitionNames).To(Equal([]string{"ns1_ib-net"}),
-				"a partition created for a NAD that raced into terminating must be rolled back")
+			Expect(apiNAD.Finalizers).To(ContainElement(utils.PartitionNADFinalizer),
+				"the finalizer must remain so deletion can clean up a partial create")
+			Expect(fabric.deletePartitionCalls).To(Equal(0))
 		})
 
 		It("skips updating a NAD that already has the same PKey and finalizer", func() {

--- a/pkg/daemon/partition_controller.go
+++ b/pkg/daemon/partition_controller.go
@@ -1,0 +1,769 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package daemon
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+
+	v1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	"github.com/rs/zerolog/log"
+	kapi "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	k8sClient "github.com/Mellanox/ib-kubernetes/pkg/k8s-client"
+	"github.com/Mellanox/ib-kubernetes/pkg/sm/plugins"
+	"github.com/Mellanox/ib-kubernetes/pkg/utils"
+	"github.com/Mellanox/ib-kubernetes/pkg/watcher"
+)
+
+// PartitionReader is the read-only view podController uses to query NAD and
+// partition state owned by partitionController. Keeping it narrow prevents
+// the pod side from accidentally mutating NAD caches or the PKey annotation.
+type PartitionReader interface {
+	GetCachedNAD(networkID string) (*v1.NetworkAttachmentDefinition, error)
+	IsPartitionManaged(networkID string) bool
+	ProcessAddIfManaged(networkID, networkName string, pods []*kapi.Pod,
+		netMap networksMap, addMap *utils.SynchronizedMap) bool
+	// DeletePartitionPods returns a non-nil error (including plugins.ErrPending)
+	// when any pod's detach failed or the backend is still converging, so the
+	// caller keeps the delete-queue entry and retries on the next tick.
+	DeletePartitionPods(networkID string, pods []*kapi.Pod) error
+}
+
+// partitionController owns NAD lifecycle for ibKubernetesEnabled networks:
+// the NAD cache, partition create/delete, PKey annotation, and the
+// PartitionNADFinalizer. It is the sole writer of utils.PartitionKeyAnnotation
+// on any NAD — pod-side code reads through PartitionReader.
+type partitionController struct {
+	// nadCache stores *v1.NetworkAttachmentDefinition keyed by networkID
+	// ("namespace_name"). Written exclusively by cacheNAD/deleteCachedNAD.
+	nadCache sync.Map
+
+	// partitionManagedCache stores the ibKubernetesEnabled bool keyed by
+	// networkID. Parsed once on cache write so isPartitionManagedNAD is a
+	// single Load — no JSON unmarshal on every hot-path call.
+	partitionManagedCache sync.Map
+
+	fabricClient plugins.FabricClient // nil for plugins that don't manage partitions
+	smClient     plugins.SubnetManagerClient
+	kubeClient   k8sClient.Client
+	nadWatcher   watcher.Watcher
+
+	// updatePodAnnotation is a function reference into podController. It lets
+	// processPartitionPods write pod annotations without owning pod state
+	// (GUID pool, kubeClient for pod calls live in podController). Set by
+	// daemon.NewDaemon after both controllers are constructed.
+	updatePodAnnotation func(*podNetworkInfo, *[]net.HardwareAddr, string) error
+}
+
+// newPartitionController returns a partitionController. updatePodAnnotation is
+// wired by the daemon constructor after podController exists; nil at this
+// point means partition-aware code paths haven't started yet.
+func newPartitionController(
+	fabricClient plugins.FabricClient,
+	smClient plugins.SubnetManagerClient,
+	kubeClient k8sClient.Client,
+	nadWatcher watcher.Watcher,
+) *partitionController {
+	return &partitionController{
+		fabricClient: fabricClient,
+		smClient:     smClient,
+		kubeClient:   kubeClient,
+		nadWatcher:   nadWatcher,
+	}
+}
+
+// networkIDForNAD returns the "namespace_name" key used everywhere the daemon
+// addresses a NAD. Single helper so the format never drifts.
+func networkIDForNAD(nad *v1.NetworkAttachmentDefinition) string {
+	return fmt.Sprintf("%s_%s", nad.Namespace, nad.Name)
+}
+
+// cacheNAD writes both the NAD and its parsed ibKubernetesEnabled bool
+// atomically. Doing both writes here is what lets isPartitionManagedNAD stay
+// a single Load.
+func (p *partitionController) cacheNAD(networkID string, nad *v1.NetworkAttachmentDefinition) {
+	p.nadCache.Store(networkID, nad)
+	p.partitionManagedCache.Store(networkID, isPartitionManagedConfig(networkID, nad.Spec.Config))
+}
+
+func (p *partitionController) deleteCachedNAD(networkID string) {
+	p.nadCache.Delete(networkID)
+	p.partitionManagedCache.Delete(networkID)
+}
+
+// IsPartitionManaged satisfies PartitionReader. Returns false for any NAD that
+// hasn't been cached yet — the parsed bit is the only source of truth.
+func (p *partitionController) IsPartitionManaged(networkID string) bool {
+	if val, ok := p.partitionManagedCache.Load(networkID); ok {
+		enabled, _ := val.(bool)
+		return enabled
+	}
+	return false
+}
+
+// getPartitionKeyFromNAD reads the PartitionKeyAnnotation off the cached NAD,
+// or empty if the NAD isn't cached / has no annotation.
+func (p *partitionController) getPartitionKeyFromNAD(networkID string) string {
+	if val, ok := p.nadCache.Load(networkID); ok {
+		nad := val.(*v1.NetworkAttachmentDefinition)
+		if nad.Annotations != nil {
+			return nad.Annotations[utils.PartitionKeyAnnotation]
+		}
+	}
+	return ""
+}
+
+// GetCachedNAD satisfies PartitionReader. Cache-then-API read; populates the
+// cache on miss so subsequent lookups are free.
+func (p *partitionController) GetCachedNAD(networkID string) (*v1.NetworkAttachmentDefinition, error) {
+	if val, ok := p.nadCache.Load(networkID); ok {
+		return val.(*v1.NetworkAttachmentDefinition), nil
+	}
+
+	networkNamespace, networkName, err := utils.ParseNetworkID(networkID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse network id %s with error: %v", networkID, err)
+	}
+
+	var netAttInfo *v1.NetworkAttachmentDefinition
+	if err = wait.ExponentialBackoff(backoffValues, func() (bool, error) {
+		var getErr error
+		netAttInfo, getErr = p.kubeClient.GetNetworkAttachmentDefinition(networkNamespace, networkName)
+		if getErr != nil {
+			if kerrors.IsNotFound(getErr) {
+				return false, getErr
+			}
+			log.Warn().Str("namespace", networkNamespace).Str("name", networkName).Err(getErr).
+				Msg("failed to get network attachment, retrying")
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		return nil, fmt.Errorf("failed to get network attachment %s/%s: %w", networkNamespace, networkName, err)
+	}
+
+	p.cacheNAD(networkID, netAttInfo)
+	return netAttInfo, nil
+}
+
+// isPartitionManagedConfig parses a NAD's CNI config and returns true when
+// ibKubernetesEnabled=true. Package-level because cacheNAD calls it eagerly.
+func isPartitionManagedConfig(networkID, config string) bool {
+	networkSpec := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(config), &networkSpec); err != nil {
+		log.Warn().Str("network_id", networkID).Err(err).Msg("failed to parse NAD config")
+		return false
+	}
+	enabled, ok := networkSpec[utils.IBKubernetesEnabled].(bool)
+	return ok && enabled
+}
+
+// hasPartitionFinalizer reports whether the NAD carries the partition finalizer
+// the controller uses to gate backend partition deletion.
+func hasPartitionFinalizer(nad *v1.NetworkAttachmentDefinition) bool {
+	for _, f := range nad.Finalizers {
+		if f == utils.PartitionNADFinalizer {
+			return true
+		}
+	}
+	return false
+}
+
+// ProcessNADChanges is the periodic tick that drives the NAD lifecycle. It
+// drains the added/deleted queues from the NAD watcher and delegates to
+// processNADResults, which contains the actual logic (split out for
+// testability — tests pass crafted maps without standing up a watcher).
+func (p *partitionController) ProcessNADChanges() {
+	nadHandler := p.nadWatcher.GetHandler().(nadResultsProvider)
+	addedNADs, deletedNADs := nadHandler.GetResults()
+	p.processNADResults(addedNADs, deletedNADs)
+}
+
+// processNADResults applies the partition lifecycle to a set of added and
+// deleted NAD queue contents. handleNADDeletion is only called when the NAD
+// carries PartitionNADFinalizer — the signal that *we* created the partition
+// (resolves A3 from PR #228 review without pushing idempotency onto plugins).
+func (p *partitionController) processNADResults(addedNADs, deletedNADs *utils.SynchronizedMap) {
+	log.Debug().Msg("Processing NAD changes...")
+
+	type nadEntry struct {
+		networkID string
+		nad       *v1.NetworkAttachmentDefinition
+	}
+	addedNADs.Lock()
+	pendingNADs := make([]nadEntry, 0, len(addedNADs.Items))
+	for networkID, nad := range addedNADs.Items {
+		pendingNADs = append(pendingNADs, nadEntry{networkID, nad.(*v1.NetworkAttachmentDefinition)})
+	}
+	addedNADs.Unlock()
+
+	for _, entry := range pendingNADs {
+		p.cacheNAD(entry.networkID, entry.nad)
+
+		if p.fabricClient != nil {
+			if err := p.setupPartitionForNAD(entry.nad); err != nil {
+				log.Warn().Msgf("Failed to setup partition for NAD %s/%s: %v (will retry)",
+					entry.nad.Namespace, entry.nad.Name, err)
+				continue
+			}
+		}
+
+		log.Info().Msgf("Successfully processed NAD add event: %s", entry.networkID)
+		addedNADs.Remove(entry.networkID)
+	}
+
+	// Backfill PKey annotation for partition-managed NADs whose partition
+	// exists but isn't annotated yet (e.g. annotation lost after a daemon
+	// restart). updateNADPartitionKey re-stores into nadCache; sync.Map
+	// permits mutation during Range, so the write-back is safe.
+	if p.fabricClient != nil {
+		p.nadCache.Range(func(key, value interface{}) bool {
+			networkID := key.(string)
+			nad := value.(*v1.NetworkAttachmentDefinition)
+			if !p.IsPartitionManaged(networkID) {
+				return true
+			}
+			if nad.Annotations != nil && nad.Annotations[utils.PartitionKeyAnnotation] != "" {
+				return true
+			}
+			ready, partitionKey, err := p.fabricClient.IsPartitionReady(networkID)
+			if err != nil {
+				log.Debug().Str("network_id", networkID).Err(err).
+					Msg("partition readiness check failed")
+				return true
+			}
+			if ready && partitionKey != "" {
+				log.Info().Str("network_id", networkID).Str("pkey", partitionKey).
+					Msg("partition ready, updating NAD with PKey")
+				if upErr := p.updateNADPartitionKey(networkID, partitionKey); upErr != nil {
+					log.Warn().Str("network_id", networkID).Err(upErr).
+						Msg("failed to update NAD partition key")
+				}
+			}
+			return true
+		})
+	}
+
+	if deletedNADs != nil {
+		// Snapshot the queue so the informer can keep enqueuing while we
+		// run blocking backend calls + retries below. Holding the lock
+		// across handleNADDeletion (which uses wait.ExponentialBackoff)
+		// would block OnUpdate/OnAdd for tens of seconds per pass.
+		deletedNADs.Lock()
+		pendingDeletes := make([]nadEntry, 0, len(deletedNADs.Items))
+		for networkID, nad := range deletedNADs.Items {
+			pendingDeletes = append(pendingDeletes, nadEntry{networkID, nad.(*v1.NetworkAttachmentDefinition)})
+		}
+		deletedNADs.Unlock()
+
+		for _, entry := range pendingDeletes {
+			// Plugins without a FabricClient never create partitions, so there
+			// is nothing to clean up backend-side — just drop the cache entry
+			// and dequeue so the deletedNADs queue does not accumulate.
+			if p.fabricClient == nil {
+				p.deleteCachedNAD(entry.networkID)
+				deletedNADs.Remove(entry.networkID)
+				continue
+			}
+
+			// Prefer the cached NAD: a same-tick updateNADPartitionKey may have
+			// added the finalizer after deletedNADs was captured.
+			nadToDelete := entry.nad
+			if cached, ok := p.nadCache.Load(entry.networkID); ok {
+				nadToDelete = cached.(*v1.NetworkAttachmentDefinition)
+			}
+
+			if !hasPartitionFinalizer(nadToDelete) {
+				p.deleteCachedNAD(entry.networkID)
+				deletedNADs.Remove(entry.networkID)
+				log.Debug().Str("network_id", entry.networkID).
+					Msg("NAD has no partition finalizer, nothing to clean up")
+				continue
+			}
+
+			log.Info().Msgf("Processing NAD delete event: %s", entry.networkID)
+			if err := p.handleNADDeletion(nadToDelete); err != nil {
+				log.Warn().Msgf("Failed to cleanup partition for NAD %s/%s: %v (will retry)",
+					entry.nad.Namespace, entry.nad.Name, err)
+				continue
+			}
+
+			p.deleteCachedNAD(entry.networkID)
+			deletedNADs.Remove(entry.networkID)
+			log.Info().Msgf("Successfully processed NAD delete event: %s", entry.networkID)
+		}
+	}
+
+	log.Debug().Msg("NAD changes processing completed")
+}
+
+// setupPartitionForNAD creates an IB partition for a NAD with
+// ibKubernetesEnabled. partitionName and the eventual networkID are the same
+// "namespace_name" string by construction (see networkIDForNAD).
+//
+// Defensive: returns nil if fabricClient is unavailable. The only caller
+// (processNADResults) already gates on fabricClient != nil, but the guard
+// here means a future refactor can't accidentally NPE.
+func (p *partitionController) setupPartitionForNAD(nad *v1.NetworkAttachmentDefinition) error {
+	if p.fabricClient == nil {
+		return nil
+	}
+	if nad.Annotations != nil && nad.Annotations[utils.PartitionKeyAnnotation] != "" {
+		log.Debug().Msgf("NAD %s/%s already has partition-key annotation", nad.Namespace, nad.Name)
+		return nil
+	}
+
+	networkSpec := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(nad.Spec.Config), &networkSpec); err != nil {
+		return fmt.Errorf("failed to parse NAD spec: %v", err)
+	}
+
+	if !utils.IsIbSriovCniSpec(networkSpec) {
+		log.Debug().Msgf("NAD %s/%s is not an ib-sriov network, skipping partition setup", nad.Namespace, nad.Name)
+		return nil
+	}
+
+	if enabled, ok := networkSpec[utils.IBKubernetesEnabled]; !ok || enabled != true {
+		log.Debug().Msgf("NAD %s/%s does not have ibKubernetesEnabled, skipping", nad.Namespace, nad.Name)
+		return nil
+	}
+
+	// Re-fetch before creating backend state: the add-queue entry is a snapshot
+	// and the NAD may have entered Terminating since it was queued. Kubernetes
+	// rejects adding a finalizer to a deleting object, so a partition created
+	// now could never carry the finalizer that drives its cleanup — it would be
+	// orphaned. Let the delete path handle an already-terminating NAD.
+	freshNAD, err := p.kubeClient.GetNetworkAttachmentDefinition(nad.Namespace, nad.Name)
+	if err != nil {
+		return fmt.Errorf("failed to fetch NAD before partition setup: %v", err)
+	}
+	if freshNAD.DeletionTimestamp != nil {
+		log.Info().Msgf("NAD %s/%s is terminating, skipping partition setup", nad.Namespace, nad.Name)
+		return nil
+	}
+
+	partitionName := networkIDForNAD(nad)
+	log.Info().Msgf("Creating IB partition for NAD %s/%s with name: %s", nad.Namespace, nad.Name, partitionName)
+
+	partitionKey, err := p.fabricClient.CreateIBPartition(partitionName)
+	if err != nil {
+		return fmt.Errorf("failed to create IB partition: %v", err)
+	}
+
+	log.Info().Msgf("Created IB partition '%s' with PKey: %s for NAD %s/%s",
+		partitionName, partitionKey, nad.Namespace, nad.Name)
+
+	var setErr error
+	if partitionKey != "" {
+		// partitionName == networkID by construction (networkIDForNAD).
+		setErr = p.updateNADPartitionKey(partitionName, partitionKey)
+	} else {
+		// PKey not assigned yet (partition not ready) — just plant the finalizer.
+		setErr = p.addNADFinalizer(nad)
+	}
+	if setErr != nil {
+		return p.rollbackPartitionIfTerminating(nad, partitionName, setErr)
+	}
+	return nil
+}
+
+// rollbackPartitionIfTerminating handles the create/delete race that survives
+// the pre-create check: the NAD can enter Terminating in the window between
+// that check and the post-create finalizer write. Kubernetes then rejects the
+// finalizer (setErr), and without our finalizer the delete path never cleans
+// up the partition we just created. Delete the partition in that case so it is
+// not orphaned; otherwise return setErr so the add loop retries a transient
+// failure.
+func (p *partitionController) rollbackPartitionIfTerminating(
+	nad *v1.NetworkAttachmentDefinition, partitionName string, setErr error,
+) error {
+	latest, getErr := p.kubeClient.GetNetworkAttachmentDefinition(nad.Namespace, nad.Name)
+	terminating := kerrors.IsNotFound(getErr) || (getErr == nil && latest.DeletionTimestamp != nil)
+	if !terminating {
+		return setErr
+	}
+
+	log.Warn().Msgf("NAD %s/%s terminating during setup; rolling back partition '%s'",
+		nad.Namespace, nad.Name, partitionName)
+	if delErr := p.fabricClient.DeleteIBPartition(partitionName); delErr != nil {
+		return fmt.Errorf("failed to roll back partition '%s' for terminating NAD %s/%s: %v",
+			partitionName, nad.Namespace, nad.Name, delErr)
+	}
+	return nil
+}
+
+// addNADFinalizer adds the partition finalizer to a NAD. The post-update
+// cacheNAD call is intentional: it refreshes the cached object with the
+// resourceVersion that now carries the finalizer.
+func (p *partitionController) addNADFinalizer(nad *v1.NetworkAttachmentDefinition) error {
+	return wait.ExponentialBackoff(backoffValues, func() (bool, error) {
+		freshNAD, err := p.kubeClient.GetNetworkAttachmentDefinition(nad.Namespace, nad.Name)
+		if err != nil {
+			return false, fmt.Errorf("failed to fetch fresh NAD: %v", err)
+		}
+
+		if hasPartitionFinalizer(freshNAD) {
+			return true, nil
+		}
+
+		freshNAD.Finalizers = append(freshNAD.Finalizers, utils.PartitionNADFinalizer)
+		if err := p.kubeClient.UpdateNetworkAttachmentDefinition(freshNAD); err != nil {
+			if kerrors.IsConflict(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("failed to add finalizer to NAD: %v", err)
+		}
+
+		p.cacheNAD(networkIDForNAD(freshNAD), freshNAD)
+		return true, nil
+	})
+}
+
+// updateNADPartitionKey annotates a NAD with its partition key and adds the
+// partition finalizer in one update. partitionController is the *only* writer
+// of this annotation; pod-side code reads it via PartitionReader.
+func (p *partitionController) updateNADPartitionKey(networkID, partitionKey string) error {
+	networkNamespace, networkName, err := utils.ParseNetworkID(networkID)
+	if err != nil {
+		return fmt.Errorf("failed to parse network id %s: %v", networkID, err)
+	}
+
+	return wait.ExponentialBackoff(backoffValues, func() (bool, error) {
+		freshNAD, err := p.kubeClient.GetNetworkAttachmentDefinition(networkNamespace, networkName)
+		if err != nil {
+			return false, fmt.Errorf("failed to fetch fresh NAD: %v", err)
+		}
+
+		if freshNAD.Annotations != nil &&
+			freshNAD.Annotations[utils.PartitionKeyAnnotation] == partitionKey &&
+			hasPartitionFinalizer(freshNAD) {
+			p.cacheNAD(networkID, freshNAD)
+			return true, nil
+		}
+
+		if freshNAD.Annotations == nil {
+			freshNAD.Annotations = make(map[string]string)
+		}
+
+		freshNAD.Annotations[utils.PartitionKeyAnnotation] = partitionKey
+
+		if !hasPartitionFinalizer(freshNAD) {
+			freshNAD.Finalizers = append(freshNAD.Finalizers, utils.PartitionNADFinalizer)
+		}
+
+		if err := p.kubeClient.UpdateNetworkAttachmentDefinition(freshNAD); err != nil {
+			if kerrors.IsConflict(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("failed to update NAD: %v", err)
+		}
+
+		log.Info().Msgf("Updated NAD %s/%s with partition-key: %s",
+			freshNAD.Namespace, freshNAD.Name, partitionKey)
+
+		p.cacheNAD(networkID, freshNAD)
+		return true, nil
+	})
+}
+
+// handleNADDeletion deletes the backend partition for a Terminating NAD and
+// then removes our finalizer so K8s can complete deletion.
+//
+// Invariant (enforced at the only caller, ProcessNADChanges): nad has
+// utils.PartitionNADFinalizer. This is the controller's contract that *we*
+// created the partition — plugins don't need DeleteIBPartition to be
+// idempotent across NADs we never touched.
+//
+// Defensive: returns nil if fabricClient is unavailable. The caller already
+// gates the call on a fabricClient != nil check; this guard ensures a future
+// refactor can't reach DeleteIBPartition through a nil pointer.
+func (p *partitionController) handleNADDeletion(nad *v1.NetworkAttachmentDefinition) error {
+	if p.fabricClient == nil {
+		return nil
+	}
+	partitionName := networkIDForNAD(nad)
+	log.Info().Msgf("Deleting IB partition '%s' for NAD %s/%s", partitionName, nad.Namespace, nad.Name)
+
+	if err := p.fabricClient.DeleteIBPartition(partitionName); err != nil {
+		return fmt.Errorf("failed to delete partition '%s': %v", partitionName, err)
+	}
+
+	log.Info().Msgf("Successfully deleted IB partition '%s'", partitionName)
+	return p.removeNADFinalizer(nad, utils.PartitionNADFinalizer)
+}
+
+// removeNADFinalizer drops finalizer from the NAD, retrying on conflict so a
+// late informer view doesn't strand a NAD in Terminating.
+func (p *partitionController) removeNADFinalizer(nad *v1.NetworkAttachmentDefinition, finalizer string) error {
+	return wait.ExponentialBackoff(backoffValues, func() (bool, error) {
+		freshNAD, err := p.kubeClient.GetNetworkAttachmentDefinition(nad.Namespace, nad.Name)
+		if err != nil {
+			if kerrors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, fmt.Errorf("failed to fetch fresh NAD: %v", err)
+		}
+
+		newFinalizers := make([]string, 0, len(freshNAD.Finalizers))
+		for _, f := range freshNAD.Finalizers {
+			if f != finalizer {
+				newFinalizers = append(newFinalizers, f)
+			}
+		}
+
+		if len(newFinalizers) == len(freshNAD.Finalizers) {
+			return true, nil
+		}
+
+		freshNAD.Finalizers = newFinalizers
+		if err := p.kubeClient.UpdateNetworkAttachmentDefinition(freshNAD); err != nil {
+			if kerrors.IsConflict(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("failed to remove finalizer from NAD: %v", err)
+		}
+
+		log.Info().Msgf("Removed finalizer %s from NAD %s/%s", finalizer, nad.Namespace, nad.Name)
+		return true, nil
+	})
+}
+
+// ProcessAddIfManaged satisfies PartitionReader. Outer gate of the
+// partition-aware pod-add path: ensures the partition has a PKey (creating
+// the annotation if needed), then delegates pod GUID work to
+// processPartitionPods. Returns true when this controller has taken
+// responsibility for the network entry — caller (podController) must then
+// skip the legacy GUID path.
+func (p *partitionController) ProcessAddIfManaged(
+	networkID string,
+	networkName string,
+	pods []*kapi.Pod,
+	netMap networksMap,
+	addMap *utils.SynchronizedMap,
+) bool {
+	if p.fabricClient == nil || !p.IsPartitionManaged(networkID) {
+		return false
+	}
+
+	partitionKey := p.getPartitionKeyFromNAD(networkID)
+	if partitionKey == "" {
+		ready, pkey, partErr := p.fabricClient.IsPartitionReady(networkID)
+		if partErr != nil {
+			log.Warn().Str("network_id", networkID).Err(partErr).
+				Msg("partition readiness check failed, will retry")
+			return true
+		}
+		if !ready || pkey == "" {
+			log.Debug().Str("network_id", networkID).Int("pods", len(pods)).
+				Msg("partition not ready, skipping pods")
+			return true
+		}
+		partitionKey = pkey
+		if err := p.updateNADPartitionKey(networkID, partitionKey); err != nil {
+			// Bind GUIDs only after the PKey annotation is persisted: the delete
+			// path derives the pkey from that annotation, so binding now would
+			// leave the GUIDs unremovable if the write never lands. Retry next tick.
+			log.Warn().Str("network_id", networkID).Err(err).
+				Msg("failed to persist PKey to NAD, will retry")
+			return true
+		}
+	}
+
+	p.processPartitionPods(pods, networkName, partitionKey, netMap, addMap, networkID)
+	return true
+}
+
+// processPartitionPods runs the per-pod IB association for a network with a
+// known PKey. Uses hardware PF GUIDs from GetNodeIBDevices (PF/fat-VM model)
+// and tolerates ErrPending for non-blocking backend provisioning.
+func (p *partitionController) processPartitionPods(
+	pods []*kapi.Pod,
+	networkName string,
+	partitionKey string,
+	netMap networksMap,
+	addMap *utils.SynchronizedMap,
+	networkID string,
+) {
+	if p.fabricClient == nil {
+		log.Debug().Str("network_id", networkID).Msg("fabric client unavailable, skipping partition add")
+		return
+	}
+
+	pKey, err := utils.ParsePKey(partitionKey)
+	if err != nil {
+		log.Error().Msgf("failed to parse partition key %s: %v", partitionKey, err)
+		return
+	}
+
+	allProcessed := true
+	for _, pod := range pods {
+		devices, devErr := p.fabricClient.GetNodeIBDevices(pod.Spec.NodeName)
+		if devErr != nil {
+			log.Error().Str("node", pod.Spec.NodeName).Err(devErr).
+				Msg("failed to get IB devices for node")
+			allProcessed = false
+			continue
+		}
+
+		guids := make([]net.HardwareAddr, 0, len(devices))
+		for _, dev := range devices {
+			guids = append(guids, dev.GUID)
+		}
+
+		if len(guids) == 0 {
+			log.Warn().Str("node", pod.Spec.NodeName).
+				Str("pod", pod.Name).Str("namespace", pod.Namespace).
+				Msg("no IB devices found on node")
+			allProcessed = false
+			continue
+		}
+
+		addErr := p.smClient.AddGuidsToPKey(pKey, guids)
+		if addErr != nil {
+			if errors.Is(addErr, plugins.ErrPending) {
+				log.Debug().Str("pod", pod.Name).Str("namespace", pod.Namespace).
+					Str("node", pod.Spec.NodeName).Int("interfaces", len(guids)).
+					Msg("backend provisioning pending")
+				allProcessed = false
+				continue
+			}
+			log.Error().Str("pod", pod.Name).Str("namespace", pod.Namespace).
+				Err(addErr).Msg("AddGuidsToPKey failed")
+			allProcessed = false
+			continue
+		}
+
+		podNetworkInfos, piErr := getAllPodNetworkInfos(networkName, pod, netMap)
+		if piErr != nil {
+			log.Error().Err(piErr).Msg("failed to get pod network infos")
+			allProcessed = false
+			continue
+		}
+
+		log.Info().Str("pod", pod.Name).Str("namespace", pod.Namespace).
+			Str("node", pod.Spec.NodeName).Str("network", networkName).
+			Str("pkey", partitionKey).Int("interfaces", len(podNetworkInfos)).
+			Msg("IB ready, annotating pod")
+
+		// Guard the injected annotation hook: nil only if a caller constructed
+		// partitionController without daemon.NewDaemon wiring it. Backend GUIDs
+		// are already attached, so keep the entry (allProcessed=false) to retry.
+		if p.updatePodAnnotation == nil {
+			log.Error().Str("network_id", networkID).Msg("updatePodAnnotation not wired; cannot annotate pod")
+			allProcessed = false
+			continue
+		}
+
+		// PF mode: only set mellanox.infiniband.app=configured (no pkey in cni-args).
+		// pi.addr is unset so the removedGUIDList sink stays empty.
+		var removedGUIDList []net.HardwareAddr
+		for _, pi := range podNetworkInfos {
+			if updateErr := p.updatePodAnnotation(pi, &removedGUIDList, ""); updateErr != nil {
+				log.Error().Err(updateErr).Msg("failed to update pod annotation")
+				allProcessed = false
+			}
+		}
+	}
+
+	if allProcessed {
+		// Reconcile against the live queue: drop only the pods we just
+		// processed, leave any the informer appended after the snapshot.
+		removeProcessedPodsFromQueue(addMap, networkID, pods)
+	}
+}
+
+// DeletePartitionPods satisfies PartitionReader. Removes each deleted pod's
+// node-level PF GUIDs from the partition. Assumes one pod per node per
+// partition (fat-VM); a per-(networkID,nodeName) refcount over live pods
+// would be needed to lift that.
+//
+// Returns the first error from PKey parse, GetNodeIBDevices, or
+// RemoveGuidsFromPKey so the caller can retain its delete-queue entry.
+// ErrPending from RemoveGuidsFromPKey (backend still moving interfaces back
+// to default) propagates through so DeletePeriodicUpdate keeps the entry
+// queued until the backend converges.
+//
+// Best-effort across pods: a per-pod failure is recorded but doesn't stop
+// the remaining pods from being processed in the same pass.
+//
+// Returns nil — entry can be dequeued — when fabricClient is absent or the
+// NAD has no PKey annotation (the partition wasn't ours).
+func (p *partitionController) DeletePartitionPods(networkID string, pods []*kapi.Pod) error {
+	if p.fabricClient == nil {
+		log.Debug().Str("network_id", networkID).Msg("fabric client unavailable, skipping partition delete")
+		return nil
+	}
+
+	partitionKey := p.getPartitionKeyFromNAD(networkID)
+	if partitionKey == "" {
+		log.Debug().Str("network_id", networkID).Msg("no partition key on NAD, skipping delete")
+		return nil
+	}
+	pKey, pkeyErr := utils.ParsePKey(partitionKey)
+	if pkeyErr != nil {
+		return fmt.Errorf("failed to parse partition key %q for network %s: %w",
+			partitionKey, networkID, pkeyErr)
+	}
+
+	var firstErr error
+	recordErr := func(err error) {
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	for _, pod := range pods {
+		devices, devErr := p.fabricClient.GetNodeIBDevices(pod.Spec.NodeName)
+		if devErr != nil {
+			log.Error().Str("node", pod.Spec.NodeName).Err(devErr).
+				Msg("failed to get IB devices for node on delete")
+			recordErr(fmt.Errorf("get IB devices for node %s: %w", pod.Spec.NodeName, devErr))
+			continue
+		}
+		guids := make([]net.HardwareAddr, 0, len(devices))
+		for _, dev := range devices {
+			guids = append(guids, dev.GUID)
+		}
+		if len(guids) == 0 {
+			continue
+		}
+		if rmErr := p.smClient.RemoveGuidsFromPKey(pKey, guids); rmErr != nil {
+			log.Warn().Str("pod", pod.Name).Str("node", pod.Spec.NodeName).
+				Err(rmErr).Msg("failed to remove GUIDs from partition on delete")
+			recordErr(fmt.Errorf("remove GUIDs from pkey %s on node %s: %w",
+				partitionKey, pod.Spec.NodeName, rmErr))
+			continue
+		}
+		log.Info().Str("pod", pod.Name).Str("node", pod.Spec.NodeName).
+			Str("pkey", partitionKey).Int("guids", len(guids)).
+			Msg("removed node GUIDs from partition")
+	}
+	return firstErr
+}
+
+// nadResultsProvider is the slice of NADEventHandler that ProcessNADChanges
+// uses. Keeping the interface narrow so the watcher handler isn't required
+// to expose its full type just for this one consumer.
+type nadResultsProvider interface {
+	GetResults() (*utils.SynchronizedMap, *utils.SynchronizedMap)
+}

--- a/pkg/daemon/partition_controller.go
+++ b/pkg/daemon/partition_controller.go
@@ -362,6 +362,13 @@ func (p *partitionController) setupPartitionForNAD(nad *v1.NetworkAttachmentDefi
 		return nil
 	}
 
+	// Persist ownership before creating backend state. If creation or the
+	// later PKey annotation fails, the finalizer keeps deletion routed through
+	// handleNADDeletion, where DeleteIBPartition is idempotent.
+	if err := p.addNADFinalizer(freshNAD); err != nil {
+		return fmt.Errorf("failed to add partition finalizer: %v", err)
+	}
+
 	partitionName := networkIDForNAD(nad)
 	log.Info().Msgf("Creating IB partition for NAD %s/%s with name: %s", nad.Namespace, nad.Name, partitionName)
 
@@ -373,42 +380,12 @@ func (p *partitionController) setupPartitionForNAD(nad *v1.NetworkAttachmentDefi
 	log.Info().Msgf("Created IB partition '%s' with PKey: %s for NAD %s/%s",
 		partitionName, partitionKey, nad.Namespace, nad.Name)
 
-	var setErr error
 	if partitionKey != "" {
 		// partitionName == networkID by construction (networkIDForNAD).
-		setErr = p.updateNADPartitionKey(partitionName, partitionKey)
-	} else {
-		// PKey not assigned yet (partition not ready) — just plant the finalizer.
-		setErr = p.addNADFinalizer(nad)
-	}
-	if setErr != nil {
-		return p.rollbackPartitionIfTerminating(nad, partitionName, setErr)
-	}
-	return nil
-}
-
-// rollbackPartitionIfTerminating handles the create/delete race that survives
-// the pre-create check: the NAD can enter Terminating in the window between
-// that check and the post-create finalizer write. Kubernetes then rejects the
-// finalizer (setErr), and without our finalizer the delete path never cleans
-// up the partition we just created. Delete the partition in that case so it is
-// not orphaned; otherwise return setErr so the add loop retries a transient
-// failure.
-func (p *partitionController) rollbackPartitionIfTerminating(
-	nad *v1.NetworkAttachmentDefinition, partitionName string, setErr error,
-) error {
-	latest, getErr := p.kubeClient.GetNetworkAttachmentDefinition(nad.Namespace, nad.Name)
-	terminating := kerrors.IsNotFound(getErr) || (getErr == nil && latest.DeletionTimestamp != nil)
-	if !terminating {
-		return setErr
+		return p.updateNADPartitionKey(partitionName, partitionKey)
 	}
 
-	log.Warn().Msgf("NAD %s/%s terminating during setup; rolling back partition '%s'",
-		nad.Namespace, nad.Name, partitionName)
-	if delErr := p.fabricClient.DeleteIBPartition(partitionName); delErr != nil {
-		return fmt.Errorf("failed to roll back partition '%s' for terminating NAD %s/%s: %v",
-			partitionName, nad.Namespace, nad.Name, delErr)
-	}
+	// PKey not assigned yet; the readiness backfill will annotate it later.
 	return nil
 }
 
@@ -665,22 +642,32 @@ func (p *partitionController) processPartitionPods(
 			Str("pkey", partitionKey).Int("interfaces", len(podNetworkInfos)).
 			Msg("IB ready, annotating pod")
 
+		annotationFailed := false
+
 		// Guard the injected annotation hook: nil only if a caller constructed
-		// partitionController without daemon.NewDaemon wiring it. Backend GUIDs
-		// are already attached, so keep the entry (allProcessed=false) to retry.
+		// partitionController without daemon.NewDaemon wiring it.
 		if p.updatePodAnnotation == nil {
 			log.Error().Str("network_id", networkID).Msg("updatePodAnnotation not wired; cannot annotate pod")
-			allProcessed = false
-			continue
+			annotationFailed = true
+		} else {
+			// PF mode: only set mellanox.infiniband.app=configured (no pkey in cni-args).
+			// pi.addr is unset so the removedGUIDList sink stays empty.
+			var removedGUIDList []net.HardwareAddr
+			for _, pi := range podNetworkInfos {
+				if updateErr := p.updatePodAnnotation(pi, &removedGUIDList, ""); updateErr != nil {
+					log.Error().Err(updateErr).Msg("failed to update pod annotation")
+					annotationFailed = true
+					break
+				}
+			}
 		}
 
-		// PF mode: only set mellanox.infiniband.app=configured (no pkey in cni-args).
-		// pi.addr is unset so the removedGUIDList sink stays empty.
-		var removedGUIDList []net.HardwareAddr
-		for _, pi := range podNetworkInfos {
-			if updateErr := p.updatePodAnnotation(pi, &removedGUIDList, ""); updateErr != nil {
-				log.Error().Err(updateErr).Msg("failed to update pod annotation")
-				allProcessed = false
+		if annotationFailed {
+			allProcessed = false
+			if rmErr := p.smClient.RemoveGuidsFromPKey(pKey, guids); rmErr != nil {
+				log.Error().Str("pod", pod.Name).Str("namespace", pod.Namespace).
+					Str("node", pod.Spec.NodeName).Err(rmErr).
+					Msg("failed to roll back GUIDs after pod annotation failure")
 			}
 		}
 	}
@@ -745,6 +732,13 @@ func (p *partitionController) DeletePartitionPods(networkID string, pods []*kapi
 			guids = append(guids, dev.GUID)
 		}
 		if len(guids) == 0 {
+			// Symmetric with processPartitionPods: for a fat-VM node that has PFs an
+			// empty inventory is a transient/cold-cache gap, not "nothing to remove".
+			// Record an error so the caller retains the delete-queue entry and retries
+			// rather than dequeuing while GUIDs stay bound to the partition.
+			log.Warn().Str("node", pod.Spec.NodeName).Str("pod", pod.Name).
+				Msg("no IB devices on node during delete; retaining entry for retry")
+			recordErr(fmt.Errorf("no IB devices for node %s (transient?), retry", pod.Spec.NodeName))
 			continue
 		}
 		if rmErr := p.smClient.RemoveGuidsFromPKey(pKey, guids); rmErr != nil {

--- a/pkg/daemon/partition_controller.go
+++ b/pkg/daemon/partition_controller.go
@@ -218,7 +218,14 @@ func (p *partitionController) processNADResults(addedNADs, deletedNADs *utils.Sy
 	addedNADs.Unlock()
 
 	for _, entry := range pendingNADs {
-		p.cacheNAD(entry.networkID, entry.nad)
+		// Don't let a stale no-finalizer add snapshot overwrite a cache entry that
+		// already carries the finalizer — the delete loop trusts the cache, so a
+		// regressed entry would hide the finalizer and skip partition cleanup.
+		if cached, ok := p.nadCache.Load(entry.networkID); !ok ||
+			!hasPartitionFinalizer(cached.(*v1.NetworkAttachmentDefinition)) ||
+			hasPartitionFinalizer(entry.nad) {
+			p.cacheNAD(entry.networkID, entry.nad)
+		}
 
 		if p.fabricClient != nil {
 			if err := p.setupPartitionForNAD(entry.nad); err != nil {
@@ -400,6 +407,11 @@ func (p *partitionController) addNADFinalizer(nad *v1.NetworkAttachmentDefinitio
 		}
 
 		if hasPartitionFinalizer(freshNAD) {
+			// Refresh the cache on the already-finalized fast path too. A later
+			// add tick can re-cache the original no-finalizer queue snapshot, and
+			// the delete path prefers the cache — a stale entry would hide the
+			// finalizer and skip partition cleanup, orphaning the partition.
+			p.cacheNAD(networkIDForNAD(freshNAD), freshNAD)
 			return true, nil
 		}
 
@@ -416,9 +428,11 @@ func (p *partitionController) addNADFinalizer(nad *v1.NetworkAttachmentDefinitio
 	})
 }
 
-// updateNADPartitionKey annotates a NAD with its partition key and adds the
-// partition finalizer in one update. partitionController is the *only* writer
-// of this annotation; pod-side code reads it via PartitionReader.
+// updateNADPartitionKey annotates a NAD with its partition key. The finalizer
+// is normally already present, planted before partition creation; the
+// conditional append here is a defensive backstop for a NAD that somehow lacks
+// it. partitionController is the *only* writer of this annotation; pod-side
+// code reads it via PartitionReader.
 func (p *partitionController) updateNADPartitionKey(networkID, partitionKey string) error {
 	networkNamespace, networkName, err := utils.ParseNetworkID(networkID)
 	if err != nil {
@@ -467,9 +481,10 @@ func (p *partitionController) updateNADPartitionKey(networkID, partitionKey stri
 // then removes our finalizer so K8s can complete deletion.
 //
 // Invariant (enforced at the only caller, ProcessNADChanges): nad has
-// utils.PartitionNADFinalizer. This is the controller's contract that *we*
-// created the partition — plugins don't need DeleteIBPartition to be
-// idempotent across NADs we never touched.
+// utils.PartitionNADFinalizer. The finalizer is planted before the backend
+// partition is created, so it marks intent, not completion: the partition may
+// never have been created. DeleteIBPartition is contractually idempotent
+// (see plugins.FabricClient), which makes that case a no-op.
 //
 // Defensive: returns nil if fabricClient is unavailable. The caller already
 // gates the call on a fabricClient != nil check; this guard ensures a future
@@ -657,6 +672,8 @@ func (p *partitionController) processPartitionPods(
 				if updateErr := p.updatePodAnnotation(pi, &removedGUIDList, ""); updateErr != nil {
 					log.Error().Err(updateErr).Msg("failed to update pod annotation")
 					annotationFailed = true
+					// Stop at the first failure: annotating a later interface would
+					// mark it configured just before the GUID rollback below.
 					break
 				}
 			}

--- a/pkg/daemon/pod_controller.go
+++ b/pkg/daemon/pod_controller.go
@@ -1,0 +1,770 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+
+	v1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	netAttUtils "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/utils"
+	"github.com/rs/zerolog/log"
+	kapi "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/Mellanox/ib-kubernetes/pkg/guid"
+	k8sClient "github.com/Mellanox/ib-kubernetes/pkg/k8s-client"
+	"github.com/Mellanox/ib-kubernetes/pkg/sm/plugins"
+	"github.com/Mellanox/ib-kubernetes/pkg/utils"
+	"github.com/Mellanox/ib-kubernetes/pkg/watcher"
+)
+
+// Temporary struct used to proceed pods' networks
+type podNetworkInfo struct {
+	pod       *kapi.Pod
+	ibNetwork *v1.NetworkSelectionElement
+	networks  []*v1.NetworkSelectionElement
+	addr      net.HardwareAddr // GUID allocated for ibNetwork and saved as net.HardwareAddr
+}
+
+type podGUIDInfo struct {
+	addr         net.HardwareAddr
+	podNetworkID string
+}
+
+type networksMap struct {
+	theMap map[types.UID][]*v1.NetworkSelectionElement
+}
+
+// getPodNetworks returns the parsed networks for a pod, caching the parse
+// result so callers iterating over many networks for the same pod don't
+// re-parse the annotation.
+func (n *networksMap) getPodNetworks(pod *kapi.Pod) ([]*v1.NetworkSelectionElement, error) {
+	networks, ok := n.theMap[pod.UID]
+	if !ok {
+		var err error
+		networks, err = netAttUtils.ParsePodNetworkAnnotation(pod)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read pod networkName annotations pod namespace %s name %s, with error: %v",
+				pod.Namespace, pod.Name, err)
+		}
+		n.theMap[pod.UID] = networks
+	}
+	return networks, nil
+}
+
+// podController owns pod-side state: the GUID pool, the (GUID -> podNetworkID)
+// map, the pod informer/watcher, and both add/delete periodic loops. It reads
+// NAD state through a narrow PartitionReader, never writing the PKey
+// annotation or other NAD fields.
+type podController struct {
+	kubeClient        k8sClient.Client
+	smClient          plugins.SubnetManagerClient
+	guidPool          guid.Pool
+	guidPodNetworkMap map[string]string // GUID -> podNetworkID
+	podWatcher        watcher.Watcher
+	partition         PartitionReader
+}
+
+// newPodController returns a podController. partition must be non-nil; pass
+// the partitionController instance returned from newPartitionController.
+func newPodController(
+	kubeClient k8sClient.Client,
+	smClient plugins.SubnetManagerClient,
+	guidPool guid.Pool,
+	podWatcher watcher.Watcher,
+	partition PartitionReader,
+) *podController {
+	return &podController{
+		kubeClient:        kubeClient,
+		smClient:          smClient,
+		guidPool:          guidPool,
+		guidPodNetworkMap: make(map[string]string),
+		podWatcher:        podWatcher,
+		partition:         partition,
+	}
+}
+
+// getIbSriovNetwork returns the network name and parsed CNI spec for a
+// networkID. The NAD itself is read through the PartitionReader so podController
+// never touches the NAD cache directly.
+func (c *podController) getIbSriovNetwork(networkID string) (string, *utils.IbSriovCniSpec, error) {
+	_, networkName, err := utils.ParseNetworkID(networkID)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to parse network id %s with error: %v", networkID, err)
+	}
+
+	netAttInfo, err := c.partition.GetCachedNAD(networkID)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to get network attachment %s: %w", networkName, err)
+	}
+	log.Debug().Msgf("networkName attachment %v", netAttInfo)
+
+	networkSpec := make(map[string]interface{})
+	err = json.Unmarshal([]byte(netAttInfo.Spec.Config), &networkSpec)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to parse networkName attachment %s with error: %v", networkName, err)
+	}
+	log.Debug().Msgf("networkName attachment spec %+v", networkSpec)
+
+	ibCniSpec, err := utils.GetIbSriovCniFromNetwork(networkSpec)
+	if err != nil {
+		return "", nil, fmt.Errorf(
+			"failed to get InfiniBand SR-IOV CNI spec from network attachment %+v, with error %v",
+			networkSpec, err)
+	}
+
+	log.Debug().Msgf("ib-sriov CNI spec %+v", ibCniSpec)
+	return networkName, ibCniSpec, nil
+}
+
+// getAllPodNetworkInfos returns one podNetworkInfo per matching interface on
+// the pod, so multi-interface pods produce multiple entries to process.
+func getAllPodNetworkInfos(netName string, pod *kapi.Pod, netMap networksMap) ([]*podNetworkInfo, error) {
+	networks, err := netMap.getPodNetworks(pod)
+	if err != nil {
+		return nil, err
+	}
+
+	matchingNetworks, err := utils.GetAllPodNetworks(networks, netName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get pod network specs for network %s with error: %v", netName, err)
+	}
+
+	podNetworkInfos := make([]*podNetworkInfo, 0, len(matchingNetworks))
+	for _, network := range matchingNetworks {
+		podNetworkInfos = append(podNetworkInfos, &podNetworkInfo{
+			pod:       pod,
+			networks:  networks,
+			ibNetwork: network,
+		})
+	}
+
+	return podNetworkInfos, nil
+}
+
+// getAllPodGUIDInfosForNetwork extracts (GUID, podNetworkID) pairs for every
+// configured InfiniBand interface on the pod matching networkName.
+func getAllPodGUIDInfosForNetwork(pod *kapi.Pod, networkName string) ([]podGUIDInfo, error) {
+	networks, netErr := netAttUtils.ParsePodNetworkAnnotation(pod)
+	if netErr != nil {
+		return nil, fmt.Errorf("failed to read pod networkName annotations pod namespace %s name %s, with error: %v",
+			pod.Namespace, pod.Name, netErr)
+	}
+
+	matchingNetworks, netErr := utils.GetAllPodNetworks(networks, networkName)
+	if netErr != nil {
+		return nil, fmt.Errorf("failed to get pod networkName specs %s with error: %v", networkName, netErr)
+	}
+
+	guidInfos := make([]podGUIDInfo, 0, len(matchingNetworks))
+	for _, network := range matchingNetworks {
+		if !utils.IsPodNetworkConfiguredWithInfiniBand(network) {
+			log.Debug().Msgf("network %+v is not InfiniBand configured, skipping", network)
+			continue
+		}
+
+		allocatedGUID, netErr := utils.GetPodNetworkGUID(network)
+		if netErr != nil {
+			log.Debug().Msgf("failed to get GUID for network interface %s: %v", network.InterfaceRequest, netErr)
+			continue
+		}
+
+		guidAddr, guidErr := net.ParseMAC(allocatedGUID)
+		if guidErr != nil {
+			log.Error().Msgf("failed to parse allocated Pod GUID %s, error: %v", allocatedGUID, guidErr)
+			continue
+		}
+
+		podNetworkID := utils.GeneratePodNetworkInterfaceID(
+			pod,
+			networkName,
+			utils.GetPodNetworkInterfaceName(networks, network),
+		)
+		guidInfos = append(guidInfos, podGUIDInfo{
+			addr:         guidAddr,
+			podNetworkID: podNetworkID,
+		})
+	}
+
+	return guidInfos, nil
+}
+
+// processPodsForNetwork iterates the pods of a network and, for each
+// interface, allocates a GUID via processNetworkGUID. Returns the list of
+// successfully allocated GUIDs and the corresponding podNetworkInfo objects.
+func (c *podController) processPodsForNetwork(
+	pods []*kapi.Pod, networkName string, ibCniSpec *utils.IbSriovCniSpec, netMap networksMap,
+) ([]net.HardwareAddr, []*podNetworkInfo) {
+	var guidList []net.HardwareAddr
+	var passedPods []*podNetworkInfo
+
+	for _, pod := range pods {
+		log.Debug().Msgf("pod namespace %s name %s", pod.Namespace, pod.Name)
+
+		podNetworkInfos, err := getAllPodNetworkInfos(networkName, pod, netMap)
+		if err != nil {
+			log.Error().Msgf("%v", err)
+			continue
+		}
+
+		for _, pi := range podNetworkInfos {
+			interfaceName := utils.GetPodNetworkInterfaceName(pi.networks, pi.ibNetwork)
+			log.Debug().Msgf("processing interface %s for network %s on pod %s", interfaceName, networkName, pod.Name)
+
+			if err = c.processNetworkGUID(networkName, ibCniSpec, pi); err != nil {
+				log.Error().Msgf("failed to process network GUID for interface %s: %v", interfaceName, err)
+				continue
+			}
+
+			guidList = append(guidList, pi.addr)
+			passedPods = append(passedPods, pi)
+		}
+	}
+
+	return guidList, passedPods
+}
+
+// allocatePodNetworkGUID makes the GUID-to-pod mapping idempotent: if the
+// GUID is already mapped to a different pod, return an error; otherwise either
+// keep the existing mapping or allocate a new one from the pool.
+func (c *podController) allocatePodNetworkGUID(
+	allocatedGUID, podNetworkID string, podUID types.UID, targetPkey string,
+) error {
+	existingPkey, _ := c.guidPool.Get(allocatedGUID)
+	if existingPkey != "" {
+		if err := c.removeStaleGUID(allocatedGUID, existingPkey); err != nil {
+			log.Warn().Msgf("failed to remove stale GUID %s from pkey %s: %v", allocatedGUID, existingPkey, err)
+		}
+	}
+	if mappedID, exist := c.guidPodNetworkMap[allocatedGUID]; exist {
+		if podNetworkID != mappedID {
+			return fmt.Errorf("failed to allocate requested guid %s, already allocated for %s",
+				allocatedGUID, mappedID)
+		}
+	} else if err := c.guidPool.AllocateGUID(allocatedGUID, targetPkey); err != nil {
+		return fmt.Errorf("failed to allocate GUID for pod ID %s, with error: %v", podUID, err)
+	} else {
+		c.guidPodNetworkMap[allocatedGUID] = podNetworkID
+	}
+
+	return nil
+}
+
+// processNetworkGUID resolves the GUID for a single pod interface — either
+// honoring a user-provided value or generating one from the pool — and
+// records it on the podNetworkInfo for the caller.
+func (c *podController) processNetworkGUID(networkID string, spec *utils.IbSriovCniSpec, pi *podNetworkInfo) error {
+	var guidAddr guid.GUID
+	allocatedGUID, err := utils.GetPodNetworkGUID(pi.ibNetwork)
+	interfaceName := utils.GetPodNetworkInterfaceName(pi.networks, pi.ibNetwork)
+	podNetworkID := utils.GeneratePodNetworkInterfaceID(pi.pod, networkID, interfaceName)
+	if err == nil {
+		guidAddr, err = guid.ParseGUID(allocatedGUID)
+		if err != nil {
+			return fmt.Errorf("failed to parse user allocated guid %s with error: %v", allocatedGUID, err)
+		}
+
+		err = c.allocatePodNetworkGUID(allocatedGUID, podNetworkID, pi.pod.UID, spec.PKey)
+		if err != nil {
+			return err
+		}
+	} else {
+		guidAddr, err = c.guidPool.GenerateGUID()
+		if err != nil {
+			switch err {
+			// Pool exhausted — resync with SM in case there are unsynced changes.
+			case guid.ErrGUIDPoolExhausted:
+				err = c.syncWithSubnetManager()
+				if err != nil {
+					return err
+				}
+			default:
+				return fmt.Errorf("failed to generate GUID for pod ID %s, with error: %v", pi.pod.UID, err)
+			}
+		}
+
+		allocatedGUID = guidAddr.String()
+		err = c.allocatePodNetworkGUID(allocatedGUID, podNetworkID, pi.pod.UID, spec.PKey)
+		if err != nil {
+			return err
+		}
+
+		err = utils.SetPodNetworkGUID(pi.ibNetwork, allocatedGUID, spec.Capabilities["infinibandGUID"])
+		if err != nil {
+			return fmt.Errorf("failed to set pod network guid with error: %v ", err)
+		}
+
+		// Record on the pod so a reschedule doesn't re-allocate.
+		netAnnotations, err := json.Marshal(pi.networks)
+		if err != nil {
+			return fmt.Errorf("failed to dump networks %+v of pod into json with error: %v", pi.networks, err)
+		}
+
+		pi.pod.Annotations[v1.NetworkAttachmentAnnot] = string(netAnnotations)
+	}
+
+	pi.addr = guidAddr.HardWareAddress()
+	return nil
+}
+
+// removeStaleGUID drops a GUID from a stale PKey via the subnet manager and
+// releases it from the pool. Used when a pod is being rescheduled across
+// pkeys and the previous binding still exists.
+func (c *podController) removeStaleGUID(allocatedGUID, existingPkey string) error {
+	parsedPkey, err := utils.ParsePKey(existingPkey)
+	if err != nil {
+		log.Error().Msgf("failed to parse PKey %s with error: %v", existingPkey, err)
+		return err
+	}
+	guidAddr, err := guid.ParseGUID(allocatedGUID)
+	if err != nil {
+		return fmt.Errorf("failed to parse user allocated guid %s with error: %v", allocatedGUID, err)
+	}
+	allocatedGUIDList := []net.HardwareAddr{guidAddr.HardWareAddress()}
+	if err = wait.ExponentialBackoff(backoffValues, func() (bool, error) {
+		log.Info().Msgf("removing guids of previous pods from pKey %s"+
+			" with subnet manager %s", existingPkey,
+			c.smClient.Name())
+		if err = c.smClient.RemoveGuidsFromPKey(parsedPkey, allocatedGUIDList); err != nil {
+			log.Warn().Msgf("failed to remove guids of removed pods from pKey %s"+
+				" with subnet manager %s with error: %v", existingPkey,
+				c.smClient.Name(), err)
+			return false, nil //nolint:nilerr // retry pattern for exponential backoff
+		}
+		return true, nil
+	}); err != nil {
+		log.Warn().Msgf("failed to remove guids of removed pods from pKey %s"+
+			" with subnet manager %s", existingPkey, c.smClient.Name())
+		return err
+	}
+
+	if err = c.guidPool.ReleaseGUID(allocatedGUID); err != nil {
+		log.Warn().Msgf("failed to release guid \"%s\" with error: %v", allocatedGUID, err)
+		return err
+	}
+	delete(c.guidPodNetworkMap, allocatedGUID)
+	log.Info().Msgf("successfully released %s from pkey %s", allocatedGUID, existingPkey)
+	return nil
+}
+
+// updatePodNetworkAnnotation writes the pod's network annotation back to the
+// API server. On failure it releases the GUID from the pool so the next pass
+// can re-allocate; the failing pod's GUID is appended to *removedList so the
+// caller can drop it from the PKey.
+//
+// partitionController invokes this through the function reference wired in
+// daemon.NewDaemon — pod state mutations stay here regardless of which loop
+// triggered them.
+func (c *podController) updatePodNetworkAnnotation(
+	pi *podNetworkInfo, removedList *[]net.HardwareAddr, pkey string,
+) error {
+	if pi.ibNetwork.CNIArgs == nil {
+		pi.ibNetwork.CNIArgs = &map[string]interface{}{}
+	}
+
+	(*pi.ibNetwork.CNIArgs)[utils.InfiniBandAnnotation] = utils.ConfiguredInfiniBandPod
+	if pkey != "" {
+		(*pi.ibNetwork.CNIArgs)[utils.PkeyAnnotation] = pkey
+	}
+
+	netAnnotations, err := json.Marshal(pi.networks)
+	if err != nil {
+		return fmt.Errorf("failed to dump networks %+v of pod into json with error: %v", pi.networks, err)
+	}
+
+	pi.pod.Annotations[v1.NetworkAttachmentAnnot] = string(netAnnotations)
+
+	if err = wait.ExponentialBackoff(backoffValues, func() (bool, error) {
+		if err = c.kubeClient.SetAnnotationsOnPod(pi.pod, pi.pod.Annotations); err != nil {
+			if kerrors.IsNotFound(err) {
+				return false, err
+			}
+			log.Warn().Msgf("failed to update pod annotations with err: %v", err)
+			return false, nil
+		}
+
+		return true, nil
+	}); err != nil {
+		log.Error().Err(err).Msg("failed to update pod annotations")
+
+		if pi.addr != nil {
+			if relErr := c.guidPool.ReleaseGUID(pi.addr.String()); relErr != nil {
+				log.Warn().Msgf("failed to release guid \"%s\" from removed pod \"%s\" in namespace "+
+					"\"%s\" with error: %v", pi.addr.String(), pi.pod.Name, pi.pod.Namespace, relErr)
+			} else {
+				delete(c.guidPodNetworkMap, pi.addr.String())
+			}
+			*removedList = append(*removedList, pi.addr)
+		}
+
+		return fmt.Errorf("failed to set pod annotations on %s/%s: %w", pi.pod.Namespace, pi.pod.Name, err)
+	}
+
+	return nil
+}
+
+// AddPeriodicUpdate is the pod-add periodic tick. For each network with
+// pending pods, it delegates the partition-aware path to PartitionReader and
+// only falls through to the legacy GUID-pool flow when partition is not
+// applicable (returns false from ProcessAddIfManaged).
+func (c *podController) AddPeriodicUpdate() {
+	log.Info().Msgf("running periodic add update")
+	addMap, _ := c.podWatcher.GetHandler().GetResults()
+
+	// Snapshot under lock so the pod informer keeps enqueuing while we process
+	// network calls. Holding the lock through backend calls would stall
+	// OnAdd/OnDelete events behind every backend call.
+	addMap.Lock()
+	snapshot := make(map[string]interface{}, len(addMap.Items))
+	for k, v := range addMap.Items {
+		snapshot[k] = v
+	}
+	addMap.Unlock()
+
+	netMap := networksMap{theMap: make(map[types.UID][]*v1.NetworkSelectionElement)}
+	for networkID, podsInterface := range snapshot {
+		log.Info().Msgf("processing network networkID %s", networkID)
+		pods, ok := podsInterface.([]*kapi.Pod)
+		if !ok {
+			log.Error().Msgf(
+				"invalid value for add map networks expected pods array \"[]*kubernetes.Pod\", found %T",
+				podsInterface)
+			continue
+		}
+
+		if len(pods) == 0 {
+			continue
+		}
+		networkName, ibCniSpec, err := c.getIbSriovNetwork(networkID)
+		if err != nil {
+			if kerrors.IsNotFound(err) {
+				log.Info().Str("network_id", networkID).Msg("NAD not found, dropping from add queue")
+				addMap.Remove(networkID)
+			} else {
+				log.Warn().Str("network_id", networkID).Err(err).Msg("NAD not ready, will retry")
+			}
+			continue
+		}
+
+		if c.partition.ProcessAddIfManaged(networkID, networkName, pods, netMap, addMap) {
+			continue
+		}
+
+		guidList, passedPods := c.processPodsForNetwork(pods, networkName, ibCniSpec, netMap)
+
+		if err = c.addPKeyAndUpdatePods(ibCniSpec, guidList, passedPods); err != nil {
+			continue
+		}
+
+		// Reconcile against the live queue: drop only the pods we just
+		// processed, leave any the informer appended after the snapshot.
+		removeProcessedPodsFromQueue(addMap, networkID, pods)
+	}
+	log.Info().Msg("add periodic update finished")
+}
+
+// addPKeyAndUpdatePods is the legacy (UFM/noop) add path: send the freshly
+// allocated GUIDs to the subnet manager, then write back per-pod annotations,
+// and remove any pod whose annotation write failed.
+func (c *podController) addPKeyAndUpdatePods(
+	ibCniSpec *utils.IbSriovCniSpec, guidList []net.HardwareAddr, passedPods []*podNetworkInfo,
+) error {
+	if ibCniSpec.PKey != "" && len(guidList) != 0 {
+		pKey, err := utils.ParsePKey(ibCniSpec.PKey)
+		if err != nil {
+			log.Error().Msgf("failed to parse PKey %s with error: %v", ibCniSpec.PKey, err)
+			return err
+		}
+
+		if err = wait.ExponentialBackoff(backoffValues, func() (bool, error) {
+			if err = c.smClient.AddGuidsToPKey(pKey, guidList); err != nil {
+				log.Warn().Msgf("failed to config pKey with subnet manager %s with error : %v",
+					c.smClient.Name(), err)
+				return false, nil //nolint:nilerr // retry on next backoff iteration
+			}
+			return true, nil
+		}); err != nil {
+			log.Error().Msgf("failed to config pKey with subnet manager %s", c.smClient.Name())
+			return err
+		}
+	}
+
+	var removedGUIDList []net.HardwareAddr
+	for _, pi := range passedPods {
+		if err := c.updatePodNetworkAnnotation(pi, &removedGUIDList, ibCniSpec.PKey); err != nil {
+			log.Error().Msgf("%v", err)
+		}
+	}
+
+	if ibCniSpec.PKey != "" && len(removedGUIDList) != 0 {
+		pKey, _ := utils.ParsePKey(ibCniSpec.PKey)
+
+		if err := wait.ExponentialBackoff(backoffValues, func() (bool, error) {
+			if rmErr := c.smClient.RemoveGuidsFromPKey(pKey, removedGUIDList); rmErr != nil {
+				log.Warn().Msgf("failed to remove guids of removed pods from pKey %s"+
+					" with subnet manager %s with error: %v", ibCniSpec.PKey,
+					c.smClient.Name(), rmErr)
+				return false, nil
+			}
+			return true, nil
+		}); err != nil {
+			log.Warn().Msgf("failed to remove guids of removed pods from pKey %s"+
+				" with subnet manager %s", ibCniSpec.PKey, c.smClient.Name())
+			return err
+		}
+	}
+
+	return nil
+}
+
+// DeletePeriodicUpdate is the pod-delete periodic tick. Partition-managed
+// networks are delegated to PartitionReader.DeletePartitionPods; everything
+// else falls through to the legacy collect-and-release GUID path.
+func (c *podController) DeletePeriodicUpdate() {
+	log.Info().Msg("running delete periodic update")
+	_, deleteMap := c.podWatcher.GetHandler().GetResults()
+
+	// Snapshot pattern as in AddPeriodicUpdate.
+	deleteMap.Lock()
+	snapshot := make(map[string]interface{}, len(deleteMap.Items))
+	for k, v := range deleteMap.Items {
+		snapshot[k] = v
+	}
+	deleteMap.Unlock()
+
+	for networkID, podsInterface := range snapshot {
+		log.Info().Msgf("processing network networkID %s", networkID)
+		pods, ok := podsInterface.([]*kapi.Pod)
+		if !ok {
+			log.Error().Msgf("invalid value for add map networks expected pods array \"[]*kubernetes.Pod\", found %T",
+				podsInterface)
+			continue
+		}
+
+		if len(pods) == 0 {
+			continue
+		}
+
+		// Warm the cache before the managed-network check: on daemon start or
+		// leader failover the first delete tick can beat the NAD informer, and a
+		// cold IsPartitionManaged would misroute a partition-managed detach to
+		// the legacy path and dequeue it without detaching (PF-mode pods carry no
+		// pool GUID). GetCachedNAD hits the API on a miss; on failure the check
+		// stays false and the legacy path handles retry. Doing this before
+		// getIbSriovNetwork also keeps a NAD fetch failure during teardown from
+		// dropping a managed detach.
+		_, _ = c.partition.GetCachedNAD(networkID)
+
+		if c.partition.IsPartitionManaged(networkID) {
+			if err := c.partition.DeletePartitionPods(networkID, pods); err != nil {
+				// Retain the queue entry so the next periodic tick retries the
+				// detach. Dropping it here would leave the node/instance
+				// attached to a partition we asked the backend to release.
+				// ErrPending also flows through here — keeps the entry until
+				// the backend confirms convergence to default partition.
+				log.Warn().Str("network_id", networkID).Err(err).
+					Msg("partition detach failed/pending, retrying on next tick")
+				continue
+			}
+			removeProcessedPodsFromQueue(deleteMap, networkID, pods)
+			continue
+		}
+
+		// Legacy path: use pool-allocated GUIDs from pod annotations.
+		networkName, ibCniSpec, err := c.getIbSriovNetwork(networkID)
+		if err != nil {
+			deleteMap.Remove(networkID)
+			log.Warn().Msgf("droping network: %v", err)
+			continue
+		}
+
+		guidList := c.collectMatchedGUIDs(pods, networkName)
+		if err = c.removePKeyAndReleaseGUIDs(ibCniSpec, guidList); err != nil {
+			continue
+		}
+		removeProcessedPodsFromQueue(deleteMap, networkID, pods)
+	}
+
+	log.Info().Msg("delete periodic update finished")
+}
+
+// collectMatchedGUIDs collects GUIDs from pods that match the given network
+// and are tracked in guidPodNetworkMap. Uses interface-aware podNetworkIDs
+// so multi-interface pods don't have GUIDs incorrectly skipped.
+func (c *podController) collectMatchedGUIDs(pods []*kapi.Pod, networkName string) []net.HardwareAddr {
+	var guidList []net.HardwareAddr
+	for _, pod := range pods {
+		log.Debug().Msgf("pod namespace %s name %s", pod.Namespace, pod.Name)
+
+		podGUIDInfos, err := getAllPodGUIDInfosForNetwork(pod, networkName)
+		if err != nil {
+			log.Error().Msgf("%v", err)
+			continue
+		}
+
+		for _, info := range podGUIDInfos {
+			if guidPodEntry, exist := c.guidPodNetworkMap[info.addr.String()]; exist {
+				if info.podNetworkID == guidPodEntry {
+					log.Info().Msgf("matched guid %s to pod %s, removing", info.addr, guidPodEntry)
+					guidList = append(guidList, info.addr)
+				} else {
+					log.Warn().Msgf("guid %s is allocated to another pod %s not %s, not removing",
+						info.addr, guidPodEntry, info.podNetworkID)
+				}
+			} else {
+				log.Warn().Msgf("guid %s is not allocated to any pod on delete", info.addr)
+			}
+		}
+	}
+	return guidList
+}
+
+// removePKeyAndReleaseGUIDs removes GUIDs from PKey via subnet manager and
+// releases them from the pool.
+func (c *podController) removePKeyAndReleaseGUIDs(ibCniSpec *utils.IbSriovCniSpec, guidList []net.HardwareAddr) error {
+	if ibCniSpec.PKey != "" && len(guidList) != 0 {
+		pKey, pkeyErr := utils.ParsePKey(ibCniSpec.PKey)
+		if pkeyErr != nil {
+			log.Error().Msgf("failed to parse PKey %s with error: %v", ibCniSpec.PKey, pkeyErr)
+			return pkeyErr
+		}
+
+		if err := wait.ExponentialBackoff(backoffValues, func() (bool, error) {
+			if rmErr := c.smClient.RemoveGuidsFromPKey(pKey, guidList); rmErr != nil {
+				log.Warn().Msgf("failed to remove guids of removed pods from pKey %s"+
+					" with subnet manager %s with error: %v", ibCniSpec.PKey,
+					c.smClient.Name(), rmErr)
+				return false, nil
+			}
+			return true, nil
+		}); err != nil {
+			log.Warn().Msgf("failed to remove guids of removed pods from pKey %s"+
+				" with subnet manager %s", ibCniSpec.PKey, c.smClient.Name())
+			return err
+		}
+	}
+
+	for _, guidAddr := range guidList {
+		if err := c.guidPool.ReleaseGUID(guidAddr.String()); err != nil {
+			log.Error().Msgf("%v", err)
+			continue
+		}
+
+		delete(c.guidPodNetworkMap, guidAddr.String())
+	}
+
+	return nil
+}
+
+// initGUIDPool rebuilds guidPodNetworkMap from running pods, then resyncs
+// with the subnet manager and prunes stale GUIDs. Called once when this
+// daemon becomes leader.
+func (c *podController) initGUIDPool() error {
+	log.Info().Msg("Initializing GUID pool.")
+
+	var pods *kapi.PodList
+	if err := wait.ExponentialBackoff(backoffValues, func() (bool, error) {
+		var err error
+		if pods, err = c.kubeClient.GetPods(kapi.NamespaceAll); err != nil {
+			log.Warn().Msgf("failed to get pods from kubernetes: %v", err)
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		err = fmt.Errorf("failed to get pods from kubernetes")
+		log.Error().Msgf("%v", err)
+		return err
+	}
+
+	for index := range pods.Items {
+		log.Debug().Msgf("checking pod for network annotations %v", pods.Items[index])
+		pod := pods.Items[index]
+		if utils.PodIsFinished(&pod) {
+			continue
+		}
+		networks, err := netAttUtils.ParsePodNetworkAnnotation(&pod)
+		if err != nil {
+			continue
+		}
+
+		for _, network := range networks {
+			if !utils.IsPodNetworkConfiguredWithInfiniBand(network) {
+				continue
+			}
+
+			podGUID, err := utils.GetPodNetworkGUID(network)
+			if err != nil {
+				continue
+			}
+
+			podNetworkID := utils.GeneratePodNetworkInterfaceID(
+				&pod,
+				network.Name,
+				utils.GetPodNetworkInterfaceName(networks, network),
+			)
+			if _, exist := c.guidPodNetworkMap[podGUID]; exist {
+				if podNetworkID != c.guidPodNetworkMap[podGUID] {
+					return fmt.Errorf("failed to allocate requested guid %s, already allocated for %s",
+						podGUID, c.guidPodNetworkMap[podGUID])
+				}
+				continue
+			}
+			podPkey, _ := utils.GetPodNetworkPkey(network)
+			if err = c.guidPool.AllocateGUID(podGUID, podPkey); err != nil {
+				err = fmt.Errorf("failed to allocate guid for running pod: %v", err)
+				log.Error().Msgf("%v", err)
+				continue
+			}
+
+			c.guidPodNetworkMap[podGUID] = podNetworkID
+		}
+	}
+
+	return c.syncWithSubnetManager()
+}
+
+// syncWithSubnetManager resets the GUID pool from the subnet manager's view
+// and prunes map entries whose GUIDs are no longer used (pod gone). Called
+// during init and whenever the pool is exhausted at runtime.
+func (c *podController) syncWithSubnetManager() error {
+	usedGuids, err := c.smClient.ListGuidsInUse()
+	if err != nil {
+		return err
+	}
+
+	if err = c.guidPool.Reset(usedGuids); err != nil {
+		return err
+	}
+
+	for allocatedGUID, podNetworkID := range c.guidPodNetworkMap {
+		if _, found := usedGuids[allocatedGUID]; !found {
+			log.Info().Msgf("removing stale GUID %s for pod network %s", allocatedGUID, podNetworkID)
+			if err = c.guidPool.ReleaseGUID(allocatedGUID); err != nil {
+				log.Warn().Msgf("failed to release stale guid \"%s\" with error: %v", allocatedGUID, err)
+			} else {
+				delete(c.guidPodNetworkMap, allocatedGUID)
+				log.Info().Msgf("successfully cleaned up stale GUID %s", allocatedGUID)
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/daemon/queue.go
+++ b/pkg/daemon/queue.go
@@ -1,0 +1,70 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package daemon
+
+import (
+	kapi "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/Mellanox/ib-kubernetes/pkg/utils"
+)
+
+// removeProcessedPodsFromQueue reconciles a periodic-loop snapshot back
+// into the live queue: it removes only the pod UIDs in 'processed' from
+// the entry at networkID, leaving any pods the informer enqueued after
+// the snapshot. If no pods remain, the entry is removed entirely.
+//
+// Use this instead of q.Remove(networkID) after processing a snapshot —
+// the unconditional Remove would discard pods that were appended to the
+// queue while the snapshot was being processed.
+func removeProcessedPodsFromQueue(q *utils.SynchronizedMap, networkID string, processed []*kapi.Pod) {
+	if len(processed) == 0 {
+		return
+	}
+	processedUIDs := make(map[types.UID]struct{}, len(processed))
+	for _, p := range processed {
+		processedUIDs[p.UID] = struct{}{}
+	}
+
+	q.Lock()
+	defer q.Unlock()
+
+	current, ok := q.Items[networkID]
+	if !ok {
+		return
+	}
+	currentPods, ok := current.([]*kapi.Pod)
+	if !ok {
+		return
+	}
+
+	// Allocate a fresh slice instead of currentPods[:0] — the underlying
+	// array may still be referenced outside this lock (e.g. by a snapshot
+	// the periodic loop hasn't finished iterating), and an in-place
+	// rewrite would corrupt those reads.
+	remaining := make([]*kapi.Pod, 0, len(currentPods))
+	for _, pod := range currentPods {
+		if _, was := processedUIDs[pod.UID]; !was {
+			remaining = append(remaining, pod)
+		}
+	}
+	if len(remaining) == 0 {
+		q.UnSafeRemove(networkID)
+		return
+	}
+	q.UnSafeSet(networkID, remaining)
+}

--- a/pkg/daemon/queue_test.go
+++ b/pkg/daemon/queue_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package daemon
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	kapi "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/Mellanox/ib-kubernetes/pkg/utils"
+)
+
+var _ = Describe("removeProcessedPodsFromQueue", func() {
+	podWithUID := func(uid, name string) *kapi.Pod {
+		return &kapi.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "ns1", UID: types.UID("uid-" + uid)},
+		}
+	}
+
+	It("preserves pods the informer enqueued after the snapshot", func() {
+		// Simulates the race: snapshot took pods [A, B]; while processing,
+		// the informer appended C. Reconcile must keep C.
+		q := utils.NewSynchronizedMap()
+		podA := podWithUID("A", "pod-A")
+		podB := podWithUID("B", "pod-B")
+		podC := podWithUID("C", "pod-C")
+
+		snapshot := []*kapi.Pod{podA, podB}
+		q.Set("ns1_ib-net", []*kapi.Pod{podA, podB, podC})
+
+		removeProcessedPodsFromQueue(q, "ns1_ib-net", snapshot)
+
+		current, ok := q.Get("ns1_ib-net")
+		Expect(ok).To(BeTrue(), "entry must remain because pod C is still pending")
+		remaining := current.([]*kapi.Pod)
+		Expect(remaining).To(HaveLen(1))
+		Expect(remaining[0].UID).To(Equal(podC.UID))
+	})
+
+	It("removes the entry when every pod was processed", func() {
+		q := utils.NewSynchronizedMap()
+		podA := podWithUID("A", "pod-A")
+		podB := podWithUID("B", "pod-B")
+
+		snapshot := []*kapi.Pod{podA, podB}
+		q.Set("ns1_ib-net", []*kapi.Pod{podA, podB})
+
+		removeProcessedPodsFromQueue(q, "ns1_ib-net", snapshot)
+
+		_, ok := q.Get("ns1_ib-net")
+		Expect(ok).To(BeFalse(), "entry must be removed when nothing remains")
+	})
+
+	It("is a no-op for an empty processed slice", func() {
+		q := utils.NewSynchronizedMap()
+		podA := podWithUID("A", "pod-A")
+		q.Set("ns1_ib-net", []*kapi.Pod{podA})
+
+		removeProcessedPodsFromQueue(q, "ns1_ib-net", nil)
+
+		current, ok := q.Get("ns1_ib-net")
+		Expect(ok).To(BeTrue())
+		Expect(current.([]*kapi.Pod)).To(HaveLen(1))
+	})
+
+	It("is a no-op when the networkID is no longer in the queue", func() {
+		q := utils.NewSynchronizedMap()
+		podA := podWithUID("A", "pod-A")
+
+		// Should not panic or error.
+		removeProcessedPodsFromQueue(q, "ns1_ib-net", []*kapi.Pod{podA})
+
+		_, ok := q.Get("ns1_ib-net")
+		Expect(ok).To(BeFalse())
+	})
+})

--- a/pkg/k8s-client/client.go
+++ b/pkg/k8s-client/client.go
@@ -38,6 +38,7 @@ type Client interface {
 	SetAnnotationsOnPod(pod *kapi.Pod, annotations map[string]string) error
 	PatchPod(pod *kapi.Pod, patchType types.PatchType, patchData []byte) error
 	GetNetworkAttachmentDefinition(namespace, name string) (*netapi.NetworkAttachmentDefinition, error)
+	UpdateNetworkAttachmentDefinition(nad *netapi.NetworkAttachmentDefinition) error
 	GetRestClient() rest.Interface
 	GetCoordinationV1() coordv1client.CoordinationV1Interface
 	GetNetClient() netclient.K8sCniCncfIoV1Interface
@@ -110,6 +111,13 @@ func (c *client) PatchPod(pod *kapi.Pod, patchType types.PatchType, patchData []
 func (c *client) GetNetworkAttachmentDefinition(namespace, name string) (*netapi.NetworkAttachmentDefinition, error) {
 	log.Debug().Msgf("getting NetworkAttachmentDefinition namespace %s, name: %s", namespace, name)
 	return c.netClient.NetworkAttachmentDefinitions(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+// UpdateNetworkAttachmentDefinition updates a NAD in the kubernetes api server
+func (c *client) UpdateNetworkAttachmentDefinition(nad *netapi.NetworkAttachmentDefinition) error {
+	log.Debug().Msgf("updating NetworkAttachmentDefinition namespace %s, name: %s", nad.Namespace, nad.Name)
+	_, err := c.netClient.NetworkAttachmentDefinitions(nad.Namespace).Update(context.TODO(), nad, metav1.UpdateOptions{})
+	return err
 }
 
 // GetRestClient returns the client rest api for k8s

--- a/pkg/k8s-client/mocks/Client.go
+++ b/pkg/k8s-client/mocks/Client.go
@@ -178,6 +178,24 @@ func (_m *Client) SetAnnotationsOnPod(pod *corev1.Pod, annotations map[string]st
 	return r0
 }
 
+// UpdateNetworkAttachmentDefinition provides a mock function with given fields: nad
+func (_m *Client) UpdateNetworkAttachmentDefinition(nad *apisk8s_cni_cncf_iov1.NetworkAttachmentDefinition) error {
+	ret := _m.Called(nad)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateNetworkAttachmentDefinition")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*apisk8s_cni_cncf_iov1.NetworkAttachmentDefinition) error); ok {
+		r0 = rf(nad)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // NewClient creates a new instance of Client. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewClient(t interface {

--- a/pkg/sm/plugins/plugin.go
+++ b/pkg/sm/plugins/plugin.go
@@ -16,7 +16,10 @@
 
 package plugins
 
-import "net"
+import (
+	"errors"
+	"net"
+)
 
 type SubnetManagerClient interface {
 	// Name returns the name of the plugin
@@ -30,6 +33,8 @@ type SubnetManagerClient interface {
 
 	// AddGuidsToPKey add pkey for the given guid.
 	// It return error if failed.
+	// For partition-aware plugins, returns ErrPending while backend is provisioning.
+	// The daemon should retry on the next periodic cycle.
 	AddGuidsToPKey(pkey int, guids []net.HardwareAddr) error
 
 	// RemoveGuidsFromPKey remove guids for given pkey.
@@ -38,4 +43,51 @@ type SubnetManagerClient interface {
 
 	// ListGuidsInUse returns a list of all GUIDS associated with PKeys
 	ListGuidsInUse() (map[string]string, error)
+}
+
+// ErrPending is returned by AddGuidsToPKey when the backend is still provisioning.
+// The daemon should keep the pod in queue and retry on the next periodic cycle.
+var ErrPending = errors.New("operation pending: backend provisioning in progress")
+
+// IBDeviceGUID represents a physical InfiniBand device with its hardware GUID.
+type IBDeviceGUID struct {
+	Device         string           // IB device name, e.g. "mlx5_0"
+	DeviceInstance int              // device instance number, e.g. 0, 1, 2, 3
+	GUID           net.HardwareAddr // hardware-assigned PF GUID
+}
+
+// FabricClient is an optional interface for plugins that manage IB partitions.
+// The daemon type-asserts to this interface at startup. Plugins that do not manage
+// partitions (e.g. UFM, noop) do not implement this interface.
+//
+// Partition lifecycle is driven by NAD events:
+//   - NAD created with ibKubernetesEnabled → daemon calls CreateIBPartition
+//   - NAD deleted → daemon calls DeleteIBPartition
+//
+// Pod binding still goes through SubnetManagerClient.AddGuidsToPKey using the
+// partition key (PKey) returned by CreateIBPartition. The plugin translates
+// PKey + GUID to backend-specific operations internally (e.g. partition ID,
+// instance ID). The daemon never sees backend-specific identifiers.
+type FabricClient interface {
+	SubnetManagerClient
+
+	// CreateIBPartition creates an IB partition with the given name (e.g. "namespace_nadName").
+	// Returns the partition key (PKey) assigned by the backend.
+	// Idempotent: if partition already exists, returns the existing PKey.
+	// The plugin internally maps name → backend partition ID.
+	CreateIBPartition(name string) (partitionKey string, err error)
+
+	// DeleteIBPartition deletes an IB partition by name.
+	// Idempotent: deleting a non-existent partition is not an error.
+	// The plugin internally looks up the backend partition ID by name.
+	DeleteIBPartition(name string) error
+
+	// IsPartitionReady checks if a partition is ready for pod binding.
+	// Returns ready status and the partition key (PKey).
+	// PKey may be empty if partition is not yet ready (assigned by backend when ready).
+	IsPartitionReady(name string) (ready bool, partitionKey string, err error)
+
+	// GetNodeIBDevices returns the IB PF devices on a node with their hardware GUIDs.
+	// Results are cached by the plugin; the daemon may call this on every cycle.
+	GetNodeIBDevices(nodeName string) ([]IBDeviceGUID, error)
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -287,6 +287,16 @@ func GenerateNetworkID(network *v1.NetworkSelectionElement) string {
 	return fmt.Sprintf("%s_%s", network.Namespace, network.Name)
 }
 
+// NetworkStatusNameToNetworkID converts a network-status name ("namespace/nadName")
+// to a networkID ("namespace_nadName"). Returns empty string if format is invalid.
+func NetworkStatusNameToNetworkID(statusName string) string {
+	parts := strings.SplitN(statusName, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s_%s", parts[0], parts[1])
+}
+
 func GeneratePodNetworkID(pod *kapi.Pod, networkID string) string {
 	return string(pod.UID) + "_" + networkID
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -38,6 +38,10 @@ const (
 	PkeyAnnotation          = "pkey"
 	ConfiguredInfiniBandPod = "configured"
 	InfiniBandSriovCni      = "ib-sriov"
+
+	PartitionKeyAnnotation = "mellanox.infiniband.pkey"
+	PartitionNADFinalizer  = "mellanox.infiniband.ib-kubernetes.io/partition"
+	IBKubernetesEnabled    = "ibKubernetesEnabled"
 )
 
 // PodWantsNetwork check if pod needs cni
@@ -188,6 +192,12 @@ func GetIbSriovCniFromNetwork(networkSpec map[string]interface{}) (*IbSriovCniSp
 	}
 
 	return nil, fmt.Errorf("cni plugin ib-sriov not found")
+}
+
+// IsIbSriovCniSpec reports whether networkSpec describes an ib-sriov CNI.
+func IsIbSriovCniSpec(networkSpec map[string]interface{}) bool {
+	_, err := GetIbSriovCniFromNetwork(networkSpec)
+	return err == nil
 }
 
 func GetPodNetwork(networks []*v1.NetworkSelectionElement, networkName string) (*v1.NetworkSelectionElement, error) {

--- a/pkg/watcher/handler/nad.go
+++ b/pkg/watcher/handler/nad.go
@@ -30,15 +30,17 @@ import (
 )
 
 type NADEventHandler struct {
-	addedNADs *utils.SynchronizedMap // Maps network ID to NAD for added NADs
-	nadCache  sync.Map               // Cache of current NADs by namespace/name
+	addedNADs   *utils.SynchronizedMap // Maps network ID to NAD for added NADs
+	deletedNADs *utils.SynchronizedMap // Maps network ID to NAD for deleted NADs
+	nadCache    sync.Map               // Cache of current NADs by namespace/name
 }
 
 // NewNADEventHandler creates a new NAD event handler
 func NewNADEventHandler() ResourceEventHandler {
 	return &NADEventHandler{
-		addedNADs: utils.NewSynchronizedMap(),
-		nadCache:  sync.Map{},
+		addedNADs:   utils.NewSynchronizedMap(),
+		deletedNADs: utils.NewSynchronizedMap(),
+		nadCache:    sync.Map{},
 	}
 }
 
@@ -74,15 +76,53 @@ func (n *NADEventHandler) OnAdd(obj interface{}, _ bool) {
 	log.Info().Msgf("Successfully processed NAD add event: %s", networkID)
 }
 
-// OnUpdate is a no-op for add-only support
-func (n *NADEventHandler) OnUpdate(oldObj, newObj interface{}) {}
+// OnUpdate handles NAD updates, including detection of DeletionTimestamp (Terminating state)
+func (n *NADEventHandler) OnUpdate(oldObj, newObj interface{}) {
+	oldNAD := oldObj.(*v1.NetworkAttachmentDefinition)
+	newNAD := newObj.(*v1.NetworkAttachmentDefinition)
 
-// OnDelete is a no-op for add-only support
-func (n *NADEventHandler) OnDelete(obj interface{}) {}
+	// Check if NAD is now terminating (has DeletionTimestamp but didn't before)
+	// This happens when a NAD with finalizers is deleted
+	if newNAD.DeletionTimestamp != nil && (oldNAD.DeletionTimestamp == nil) {
+		log.Info().Msgf("NAD entering terminating state: namespace %s name %s", newNAD.Namespace, newNAD.Name)
 
-// GetResults returns the results maps for processing by the daemon
+		// Only handle InfiniBand SR-IOV networks
+		if !n.isInfiniBandNetwork(newNAD) {
+			log.Debug().Msgf("NAD %s/%s is not an InfiniBand network, skipping termination processing",
+				newNAD.Namespace, newNAD.Name)
+			return
+		}
+
+		networkID := fmt.Sprintf("%s_%s", newNAD.Namespace, newNAD.Name)
+
+		// Add to deletion processing queue (treat as delete event)
+		// Note: If already in queue, this will update with latest NAD object
+		n.deletedNADs.Set(networkID, newNAD)
+
+		log.Info().Msgf("Added terminating NAD to deletion queue: %s", networkID)
+	}
+}
+
+// OnDelete handles NAD deletion events (NAD fully removed from K8s)
+// Cleanup is handled in OnUpdate when DeletionTimestamp is set (Terminating state).
+// OnDelete fires AFTER finalizer is removed and NAD is fully gone.
+func (n *NADEventHandler) OnDelete(obj interface{}) {
+	nad, ok := obj.(*v1.NetworkAttachmentDefinition)
+	if !ok {
+		log.Debug().Msg("NAD delete event: unexpected object type")
+		return
+	}
+
+	networkID := fmt.Sprintf("%s_%s", nad.Namespace, nad.Name)
+	log.Debug().Msgf("NAD delete event: %s", networkID)
+
+	// Clean up cache (NAD is gone)
+	n.nadCache.Delete(networkID)
+}
+
+// GetResults returns the added and deleted NADs maps for processing by the daemon
 func (n *NADEventHandler) GetResults() (*utils.SynchronizedMap, *utils.SynchronizedMap) {
-	return n.addedNADs, nil
+	return n.addedNADs, n.deletedNADs
 }
 
 // GetNADFromCache retrieves a cached NAD by network ID

--- a/pkg/watcher/handler/nad.go
+++ b/pkg/watcher/handler/nad.go
@@ -19,7 +19,6 @@ package handler
 import (
 	"encoding/json"
 	"fmt"
-	"sync"
 
 	v1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"github.com/rs/zerolog/log"
@@ -32,7 +31,6 @@ import (
 type NADEventHandler struct {
 	addedNADs   *utils.SynchronizedMap // Maps network ID to NAD for added NADs
 	deletedNADs *utils.SynchronizedMap // Maps network ID to NAD for deleted NADs
-	nadCache    sync.Map               // Cache of current NADs by namespace/name
 }
 
 // NewNADEventHandler creates a new NAD event handler
@@ -40,7 +38,6 @@ func NewNADEventHandler() ResourceEventHandler {
 	return &NADEventHandler{
 		addedNADs:   utils.NewSynchronizedMap(),
 		deletedNADs: utils.NewSynchronizedMap(),
-		nadCache:    sync.Map{},
 	}
 }
 
@@ -67,12 +64,17 @@ func (n *NADEventHandler) OnAdd(obj interface{}, _ bool) {
 
 	networkID := fmt.Sprintf("%s_%s", nad.Namespace, nad.Name)
 
-	// Cache the NAD for future reference
-	n.nadCache.Store(networkID, nad)
+	// Informer-replay case: daemon restarted while the NAD was already
+	// Terminating. k8s delivers existing objects through OnAdd; route to
+	// the deletion queue so handleNADDeletion runs the finalizer cleanup
+	// instead of the add path treating it as new.
+	if nad.DeletionTimestamp != nil {
+		n.deletedNADs.Set(networkID, nad)
+		log.Info().Msgf("NAD already terminating at add; routed to deletion queue: %s", networkID)
+		return
+	}
 
-	// Add to processing queue
 	n.addedNADs.Set(networkID, nad)
-
 	log.Info().Msgf("Successfully processed NAD add event: %s", networkID)
 }
 
@@ -81,12 +83,10 @@ func (n *NADEventHandler) OnUpdate(oldObj, newObj interface{}) {
 	oldNAD := oldObj.(*v1.NetworkAttachmentDefinition)
 	newNAD := newObj.(*v1.NetworkAttachmentDefinition)
 
-	// Check if NAD is now terminating (has DeletionTimestamp but didn't before)
-	// This happens when a NAD with finalizers is deleted
+	// Detect entry into Terminating: DeletionTimestamp just appeared.
 	if newNAD.DeletionTimestamp != nil && (oldNAD.DeletionTimestamp == nil) {
 		log.Info().Msgf("NAD entering terminating state: namespace %s name %s", newNAD.Namespace, newNAD.Name)
 
-		// Only handle InfiniBand SR-IOV networks
 		if !n.isInfiniBandNetwork(newNAD) {
 			log.Debug().Msgf("NAD %s/%s is not an InfiniBand network, skipping termination processing",
 				newNAD.Namespace, newNAD.Name)
@@ -95,17 +95,18 @@ func (n *NADEventHandler) OnUpdate(oldObj, newObj interface{}) {
 
 		networkID := fmt.Sprintf("%s_%s", newNAD.Namespace, newNAD.Name)
 
-		// Add to deletion processing queue (treat as delete event)
-		// Note: If already in queue, this will update with latest NAD object
+		// Add to deletion processing queue (treat as delete event).
+		// Note: if already in queue, this updates with latest NAD object.
 		n.deletedNADs.Set(networkID, newNAD)
+		n.addedNADs.Remove(networkID)
 
 		log.Info().Msgf("Added terminating NAD to deletion queue: %s", networkID)
 	}
 }
 
-// OnDelete handles NAD deletion events (NAD fully removed from K8s)
-// Cleanup is handled in OnUpdate when DeletionTimestamp is set (Terminating state).
-// OnDelete fires AFTER finalizer is removed and NAD is fully gone.
+// OnDelete handles NAD deletion events (NAD fully removed from K8s).
+// Partition cleanup is handled in OnUpdate when DeletionTimestamp is set;
+// OnDelete fires only AFTER the finalizer is removed and the NAD is gone.
 func (n *NADEventHandler) OnDelete(obj interface{}) {
 	nad, ok := obj.(*v1.NetworkAttachmentDefinition)
 	if !ok {
@@ -115,9 +116,7 @@ func (n *NADEventHandler) OnDelete(obj interface{}) {
 
 	networkID := fmt.Sprintf("%s_%s", nad.Namespace, nad.Name)
 	log.Debug().Msgf("NAD delete event: %s", networkID)
-
-	// Clean up cache (NAD is gone)
-	n.nadCache.Delete(networkID)
+	n.addedNADs.Remove(networkID)
 }
 
 // GetResults returns the added and deleted NADs maps for processing by the daemon
@@ -125,24 +124,14 @@ func (n *NADEventHandler) GetResults() (*utils.SynchronizedMap, *utils.Synchroni
 	return n.addedNADs, n.deletedNADs
 }
 
-// GetNADFromCache retrieves a cached NAD by network ID
-func (n *NADEventHandler) GetNADFromCache(networkID string) (*v1.NetworkAttachmentDefinition, bool) {
-	if nad, ok := n.nadCache.Load(networkID); ok {
-		return nad.(*v1.NetworkAttachmentDefinition), true
-	}
-	return nil, false
-}
-
 // isInfiniBandNetwork checks if the NAD is for InfiniBand SR-IOV
 func (n *NADEventHandler) isInfiniBandNetwork(nad *v1.NetworkAttachmentDefinition) bool {
-	// Parse the network configuration
 	var networkConfig map[string]interface{}
 	if err := json.Unmarshal([]byte(nad.Spec.Config), &networkConfig); err != nil {
 		log.Error().Msgf("Failed to parse NAD config for %s/%s: %v", nad.Namespace, nad.Name, err)
 		return false
 	}
 
-	// Check if this is an ib-sriov network
 	if cniType, ok := networkConfig["type"]; ok {
 		return cniType == utils.InfiniBandSriovCni
 	}

--- a/pkg/watcher/handler/nad_test.go
+++ b/pkg/watcher/handler/nad_test.go
@@ -17,6 +17,8 @@
 package handler
 
 import (
+	"time"
+
 	v1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -90,7 +92,226 @@ var _ = Describe("NAD Event Handler", func() {
 		})
 	})
 
-	// Note: Only NAD add functionality is tested as update/delete operations are not supported
+	Describe("OnUpdate", func() {
+		Context("when NAD enters terminating state (DeletionTimestamp set)", func() {
+			It("should add InfiniBand NAD to deletedNADs queue", func() {
+				oldNAD := &v1.NetworkAttachmentDefinition{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-ib-network",
+						Namespace: "default",
+					},
+					Spec: v1.NetworkAttachmentDefinitionSpec{
+						Config: `{"type": "ib-sriov", "pkey": "0x7fff"}`,
+					},
+				}
+
+				now := metav1.NewTime(time.Now())
+				newNAD := &v1.NetworkAttachmentDefinition{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "test-ib-network",
+						Namespace:         "default",
+						DeletionTimestamp: &now,
+					},
+					Spec: v1.NetworkAttachmentDefinitionSpec{
+						Config: `{"type": "ib-sriov", "pkey": "0x7fff"}`,
+					},
+				}
+
+				nadHandler.OnUpdate(oldNAD, newNAD)
+
+				_, deletedNADs := nadHandler.GetResults()
+				networkID := "default_test-ib-network"
+
+				result, exists := deletedNADs.Get(networkID)
+				Expect(exists).To(BeTrue())
+				Expect(result).To(Equal(newNAD))
+			})
+
+			It("should not add non-InfiniBand NAD to deletedNADs queue", func() {
+				oldNAD := &v1.NetworkAttachmentDefinition{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-other-network",
+						Namespace: "default",
+					},
+					Spec: v1.NetworkAttachmentDefinitionSpec{
+						Config: `{"type": "sriov"}`,
+					},
+				}
+
+				now := metav1.NewTime(time.Now())
+				newNAD := &v1.NetworkAttachmentDefinition{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "test-other-network",
+						Namespace:         "default",
+						DeletionTimestamp: &now,
+					},
+					Spec: v1.NetworkAttachmentDefinitionSpec{
+						Config: `{"type": "sriov"}`,
+					},
+				}
+
+				nadHandler.OnUpdate(oldNAD, newNAD)
+
+				_, deletedNADs := nadHandler.GetResults()
+				networkID := "default_test-other-network"
+
+				_, exists := deletedNADs.Get(networkID)
+				Expect(exists).To(BeFalse())
+			})
+		})
+
+		Context("when NAD update is not a termination", func() {
+			It("should ignore updates where DeletionTimestamp is not set", func() {
+				oldNAD := &v1.NetworkAttachmentDefinition{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-ib-network",
+						Namespace: "default",
+					},
+					Spec: v1.NetworkAttachmentDefinitionSpec{
+						Config: `{"type": "ib-sriov", "pkey": "0x7fff"}`,
+					},
+				}
+
+				newNAD := &v1.NetworkAttachmentDefinition{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-ib-network",
+						Namespace: "default",
+					},
+					Spec: v1.NetworkAttachmentDefinitionSpec{
+						Config: `{"type": "ib-sriov", "pkey": "0x8fff"}`,
+					},
+				}
+
+				nadHandler.OnUpdate(oldNAD, newNAD)
+
+				_, deletedNADs := nadHandler.GetResults()
+				networkID := "default_test-ib-network"
+
+				_, exists := deletedNADs.Get(networkID)
+				Expect(exists).To(BeFalse())
+			})
+
+			It("should ignore updates where DeletionTimestamp was already set", func() {
+				now := metav1.NewTime(time.Now())
+				oldNAD := &v1.NetworkAttachmentDefinition{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "test-ib-network",
+						Namespace:         "default",
+						DeletionTimestamp: &now,
+					},
+					Spec: v1.NetworkAttachmentDefinitionSpec{
+						Config: `{"type": "ib-sriov", "pkey": "0x7fff"}`,
+					},
+				}
+
+				newNAD := &v1.NetworkAttachmentDefinition{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "test-ib-network",
+						Namespace:         "default",
+						DeletionTimestamp: &now,
+					},
+					Spec: v1.NetworkAttachmentDefinitionSpec{
+						Config: `{"type": "ib-sriov", "pkey": "0x7fff"}`,
+					},
+				}
+
+				nadHandler.OnUpdate(oldNAD, newNAD)
+
+				_, deletedNADs := nadHandler.GetResults()
+				networkID := "default_test-ib-network"
+
+				_, exists := deletedNADs.Get(networkID)
+				Expect(exists).To(BeFalse())
+			})
+		})
+	})
+
+	Describe("OnDelete", func() {
+		It("should remove NAD from cache", func() {
+			nad := &v1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ib-network",
+					Namespace: "default",
+				},
+				Spec: v1.NetworkAttachmentDefinitionSpec{
+					Config: `{"type": "ib-sriov", "pkey": "0x7fff"}`,
+				},
+			}
+
+			// Add the NAD first so it's in the cache
+			nadHandler.OnAdd(nad, false)
+
+			nadHandlerImpl := nadHandler.(*NADEventHandler)
+			cachedNAD, exists := nadHandlerImpl.GetNADFromCache("default_test-ib-network")
+			Expect(exists).To(BeTrue())
+			Expect(cachedNAD).To(Equal(nad))
+
+			// Delete should clean up the cache entry
+			nadHandler.OnDelete(nad)
+
+			_, exists = nadHandlerImpl.GetNADFromCache("default_test-ib-network")
+			Expect(exists).To(BeFalse())
+		})
+
+		It("should handle unexpected object type gracefully", func() {
+			// Passing a non-NAD object should not panic
+			nadHandler.OnDelete("not-a-nad-object")
+		})
+	})
+
+	Describe("GetResults", func() {
+		It("should return both addedNADs and deletedNADs maps", func() {
+			addedNADs, deletedNADs := nadHandler.GetResults()
+			Expect(addedNADs).ToNot(BeNil())
+			Expect(deletedNADs).ToNot(BeNil())
+		})
+
+		It("should contain added NADs in the first map and deleted NADs in the second", func() {
+			ibNAD := &v1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ib-network",
+					Namespace: "default",
+				},
+				Spec: v1.NetworkAttachmentDefinitionSpec{
+					Config: `{"type": "ib-sriov", "pkey": "0x7fff"}`,
+				},
+			}
+
+			// Trigger an add
+			nadHandler.OnAdd(ibNAD, false)
+
+			// Trigger a termination via OnUpdate
+			now := metav1.NewTime(time.Now())
+			terminatingNAD := &v1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-ib-delete",
+					Namespace:         "kube-system",
+					DeletionTimestamp: &now,
+				},
+				Spec: v1.NetworkAttachmentDefinitionSpec{
+					Config: `{"type": "ib-sriov", "pkey": "0x1234"}`,
+				},
+			}
+			oldNAD := &v1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ib-delete",
+					Namespace: "kube-system",
+				},
+				Spec: v1.NetworkAttachmentDefinitionSpec{
+					Config: `{"type": "ib-sriov", "pkey": "0x1234"}`,
+				},
+			}
+			nadHandler.OnUpdate(oldNAD, terminatingNAD)
+
+			addedNADs, deletedNADs := nadHandler.GetResults()
+
+			_, addedExists := addedNADs.Get("default_test-ib-network")
+			Expect(addedExists).To(BeTrue())
+
+			_, deletedExists := deletedNADs.Get("kube-system_test-ib-delete")
+			Expect(deletedExists).To(BeTrue())
+		})
+	})
 
 	Describe("GetNADFromCache", func() {
 		It("should retrieve cached NAD", func() {

--- a/pkg/watcher/handler/nad_test.go
+++ b/pkg/watcher/handler/nad_test.go
@@ -90,6 +90,36 @@ var _ = Describe("NAD Event Handler", func() {
 				Expect(exists).To(BeFalse())
 			})
 		})
+
+		Context("with InfiniBand NAD already terminating (daemon-restart informer replay)", func() {
+			It("should route to deletedNADs, not addedNADs", func() {
+				now := metav1.NewTime(time.Now())
+				nad := &v1.NetworkAttachmentDefinition{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "test-ib-network",
+						Namespace:         "default",
+						DeletionTimestamp: &now,
+					},
+					Spec: v1.NetworkAttachmentDefinitionSpec{
+						Config: `{"type": "ib-sriov", "pkey": "0x7fff"}`,
+					},
+				}
+
+				nadHandler.OnAdd(nad, true)
+
+				addedNADs, deletedNADs := nadHandler.GetResults()
+				networkID := "default_test-ib-network"
+
+				_, addedExists := addedNADs.Get(networkID)
+				Expect(addedExists).To(BeFalse(),
+					"terminating NAD must not enter the add queue")
+
+				result, deletedExists := deletedNADs.Get(networkID)
+				Expect(deletedExists).To(BeTrue(),
+					"terminating NAD must enter the delete queue so handleNADDeletion runs")
+				Expect(result).To(Equal(nad))
+			})
+		})
 	})
 
 	Describe("OnUpdate", func() {
@@ -125,6 +155,34 @@ var _ = Describe("NAD Event Handler", func() {
 				result, exists := deletedNADs.Get(networkID)
 				Expect(exists).To(BeTrue())
 				Expect(result).To(Equal(newNAD))
+			})
+
+			It("should remove pending add retry for terminating NAD", func() {
+				oldNAD := &v1.NetworkAttachmentDefinition{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-ib-network",
+						Namespace: "default",
+					},
+					Spec: v1.NetworkAttachmentDefinitionSpec{
+						Config: `{"type": "ib-sriov", "pkey": "0x7fff"}`,
+					},
+				}
+				nadHandler.OnAdd(oldNAD, false)
+
+				now := metav1.NewTime(time.Now())
+				newNAD := oldNAD.DeepCopy()
+				newNAD.DeletionTimestamp = &now
+
+				nadHandler.OnUpdate(oldNAD, newNAD)
+
+				addedNADs, deletedNADs := nadHandler.GetResults()
+				networkID := "default_test-ib-network"
+
+				_, addedExists := addedNADs.Get(networkID)
+				Expect(addedExists).To(BeFalse())
+
+				_, deletedExists := deletedNADs.Get(networkID)
+				Expect(deletedExists).To(BeTrue())
 			})
 
 			It("should not add non-InfiniBand NAD to deletedNADs queue", func() {
@@ -227,7 +285,7 @@ var _ = Describe("NAD Event Handler", func() {
 	})
 
 	Describe("OnDelete", func() {
-		It("should remove NAD from cache", func() {
+		It("should remove pending add retry", func() {
 			nad := &v1.NetworkAttachmentDefinition{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ib-network",
@@ -238,18 +296,11 @@ var _ = Describe("NAD Event Handler", func() {
 				},
 			}
 
-			// Add the NAD first so it's in the cache
 			nadHandler.OnAdd(nad, false)
-
-			nadHandlerImpl := nadHandler.(*NADEventHandler)
-			cachedNAD, exists := nadHandlerImpl.GetNADFromCache("default_test-ib-network")
-			Expect(exists).To(BeTrue())
-			Expect(cachedNAD).To(Equal(nad))
-
-			// Delete should clean up the cache entry
 			nadHandler.OnDelete(nad)
 
-			_, exists = nadHandlerImpl.GetNADFromCache("default_test-ib-network")
+			addedNADs, _ := nadHandler.GetResults()
+			_, exists := addedNADs.Get("default_test-ib-network")
 			Expect(exists).To(BeFalse())
 		})
 
@@ -313,34 +364,4 @@ var _ = Describe("NAD Event Handler", func() {
 		})
 	})
 
-	Describe("GetNADFromCache", func() {
-		It("should retrieve cached NAD", func() {
-			nad := &v1.NetworkAttachmentDefinition{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-ib-network",
-					Namespace: "default",
-				},
-				Spec: v1.NetworkAttachmentDefinitionSpec{
-					Config: `{"type": "ib-sriov", "pkey": "0x7fff"}`,
-				},
-			}
-
-			// First add the NAD
-			nadHandler.OnAdd(nad, false)
-
-			// Then retrieve from cache
-			nadHandlerImpl := nadHandler.(*NADEventHandler)
-			cachedNAD, exists := nadHandlerImpl.GetNADFromCache("default_test-ib-network")
-
-			Expect(exists).To(BeTrue())
-			Expect(cachedNAD).To(Equal(nad))
-		})
-
-		It("should return false for non-existent NAD", func() {
-			nadHandlerImpl := nadHandler.(*NADEventHandler)
-			_, exists := nadHandlerImpl.GetNADFromCache("nonexistent/network")
-
-			Expect(exists).To(BeFalse())
-		})
-	})
 })

--- a/pkg/watcher/handler/pod.go
+++ b/pkg/watcher/handler/pod.go
@@ -26,6 +26,7 @@ import (
 	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/Mellanox/ib-kubernetes/pkg/utils"
 )
@@ -142,40 +143,162 @@ func (p *podEventHandler) OnDelete(obj interface{}) {
 		return
 	}
 
-	if !utils.HasNetworkAttachmentAnnot(pod) {
-		log.Debug().Msgf("pod doesn't have network annotation \"%v\"", v1.NetworkAttachmentAnnot)
-		return
+	// Clean addedPods for this UID; a pod queued via OnAdd may be deleted
+	// before reaching the configured state, bypassing both delete paths below.
+	p.removePodFromAddedQueueByUID(pod.UID)
+
+	// Try primary path: parse cni-args from network annotation
+	if utils.HasNetworkAttachmentAnnot(pod) {
+		if p.deleteFromNetworkAnnotation(pod) {
+			return
+		}
 	}
 
+	p.deleteFromNetworkStatus(pod)
+}
+
+// deleteFromNetworkAnnotation queues pod for delete using cni-args from k8s.v1.cni.cncf.io/networks.
+// Returns true if at least one IB network was found and queued.
+func (p *podEventHandler) deleteFromNetworkAnnotation(pod *kapi.Pod) bool {
 	networks, err := netAttUtils.ParsePodNetworkAnnotation(pod)
 	if err != nil {
-		log.Error().Msgf("failed to parse network annotations with error: %v", err)
-		return
+		log.Debug().Msgf("failed to parse network annotations for pod %s: %v", pod.Name, err)
+		return false
 	}
 
+	queued := false
 	for _, network := range networks {
 		if !utils.IsPodNetworkConfiguredWithInfiniBand(network) {
 			continue
 		}
 
-		// check if pod network has guid
 		if !utils.PodNetworkHasGUID(network) {
-			log.Error().Msgf("pod %s has network %s marked as configured with InfiniBand without having guid",
+			log.Debug().Msgf("pod %s network %s has no guid (PF mode), queuing for delete",
 				pod.Name, network.Name)
-			continue
 		}
 
 		networkID := utils.GenerateNetworkID(network)
-		pods, ok := p.deletedPods.Get(networkID)
-		if !ok {
-			pods = []*kapi.Pod{pod}
-		} else {
-			pods = append(pods.([]*kapi.Pod), pod)
-		}
-		p.deletedPods.Set(networkID, pods)
+		p.queuePodForDelete(pod, networkID)
+		queued = true
 	}
 
-	log.Info().Msgf("successfully deleted namespace %s name %s", pod.Namespace, pod.Name)
+	if queued {
+		log.Info().Msgf("successfully queued pod %s/%s for delete via network annotation",
+			pod.Namespace, pod.Name)
+	}
+	return queued
+}
+
+// deleteFromNetworkStatus queues pod for delete using k8s.v1.cni.cncf.io/network-status.
+// Used when cni-args are not present on the pod's network annotation.
+func (p *podEventHandler) deleteFromNetworkStatus(pod *kapi.Pod) {
+	statuses, err := netAttUtils.GetNetworkStatus(pod)
+	if err != nil {
+		log.Debug().Msgf("pod %s has no network-status annotation: %v", pod.Name, err)
+		return
+	}
+
+	queued := false
+	seen := make(map[string]bool)
+	for _, status := range statuses {
+		// Skip non-SR-IOV networks (no device-info means no PCI passthrough)
+		if status.DeviceInfo == nil {
+			continue
+		}
+		// network-status name is "namespace/nadName" — convert to networkID "namespace_nadName"
+		networkID := utils.NetworkStatusNameToNetworkID(status.Name)
+		if networkID == "" {
+			continue
+		}
+		if seen[networkID] {
+			continue
+		}
+		seen[networkID] = true
+		p.queuePodForDelete(pod, networkID)
+		queued = true
+	}
+
+	if queued {
+		log.Info().Msgf("successfully queued pod %s/%s for delete via network-status fallback",
+			pod.Namespace, pod.Name)
+	}
+}
+
+func (p *podEventHandler) queuePodForDelete(pod *kapi.Pod, networkID string) {
+	// addedPods cleanup happens at the top of OnDelete via
+	// removePodFromAddedQueueByUID — handles the case where the deleted
+	// pod's network annotation is incomplete (failed CNI / stripped cni-args).
+
+	var pods []*kapi.Pod
+	if existing, ok := p.deletedPods.Get(networkID); ok {
+		pods = existing.([]*kapi.Pod)
+		// Dedup by UID only when the pod actually has one. Tests may construct
+		// bare pods without a UID; in that case, fall through to append so we
+		// don't collapse distinct test pods into a single entry.
+		if pod.UID != "" {
+			for _, queued := range pods {
+				if queued.UID == pod.UID {
+					return
+				}
+			}
+		}
+	}
+	p.deletedPods.Set(networkID, append(pods, pod))
+}
+
+// removePodFromAddedQueueByUID scans every networkID in addedPods and drops
+// the entry that matches podUID. Used in OnDelete so a pod that was queued
+// for add (via OnAdd) but later deleted — without ever reaching the
+// 'configured' or network-status state — doesn't keep AddPeriodicUpdate
+// retrying SetAnnotationsOnPod (404) and AddGuidsToPKey on a UID that no
+// longer exists.
+//
+// We have to scan because we don't know which networkID(s) the pod was
+// queued under — the pod's annotation may be incomplete by delete time.
+// Atomic under addedPods' lock so a concurrent OnAdd can't re-introduce a
+// stale UID between read and write.
+func (p *podEventHandler) removePodFromAddedQueueByUID(podUID types.UID) {
+	if podUID == "" {
+		return
+	}
+	p.addedPods.Lock()
+	defer p.addedPods.Unlock()
+
+	// Collect mutations first; do not call Un*Safe* methods while ranging
+	// over Items (Go map iteration + concurrent modification is unsafe).
+	type pendingUpdate struct {
+		remove bool
+		pods   []*kapi.Pod
+	}
+	updates := make(map[string]pendingUpdate)
+
+	for networkID, val := range p.addedPods.Items {
+		pods, ok := val.([]*kapi.Pod)
+		if !ok {
+			continue
+		}
+		matched := false
+		remaining := make([]*kapi.Pod, 0, len(pods))
+		for _, queued := range pods {
+			if queued.UID == podUID {
+				matched = true
+				continue
+			}
+			remaining = append(remaining, queued)
+		}
+		if !matched {
+			continue
+		}
+		updates[networkID] = pendingUpdate{remove: len(remaining) == 0, pods: remaining}
+	}
+
+	for networkID, u := range updates {
+		if u.remove {
+			p.addedPods.UnSafeRemove(networkID)
+		} else {
+			p.addedPods.UnSafeSet(networkID, u.pods)
+		}
+	}
 }
 
 func (p *podEventHandler) GetResults() (*utils.SynchronizedMap, *utils.SynchronizedMap) {

--- a/pkg/watcher/handler/pod_test.go
+++ b/pkg/watcher/handler/pod_test.go
@@ -188,19 +188,110 @@ var _ = Describe("Pod Event Handler", func() {
 			pod3 := &kapi.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
 				v1.NetworkAttachmentAnnot: `[invalid]`}},
 				Spec: kapi.PodSpec{}}
-			// InfiniBand configured without guid
-			pod4 := &kapi.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-				v1.NetworkAttachmentAnnot: `[{"name":"test", "cni-args":{"mellanox.infiniband.app":"configured"}}]`}},
-				Spec: kapi.PodSpec{}}
 
 			podEventHandler := NewPodEventHandler()
 			podEventHandler.OnDelete(pod1)
 			podEventHandler.OnDelete(pod2)
 			podEventHandler.OnDelete(pod3)
-			podEventHandler.OnDelete(pod4)
 
 			_, delMap := podEventHandler.GetResults()
 			Expect(len(delMap.Items)).To(Equal(0))
+		})
+		It("OnDelete clears the matching pod from addedPods (configured pod)", func() {
+			// Configured pod path: pod was queued via OnAdd, became configured
+			// (cni-args has mellanox.infiniband.app=configured), then deleted.
+			// queuePodForDelete fires, and OnDelete's top-of-function scan also
+			// independently cleans addedPods by UID.
+			pod := &kapi.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "p1", Namespace: "default", UID: "uid-p1",
+					Annotations: map[string]string{
+						v1.NetworkAttachmentAnnot: `[{"name":"test","namespace":"default","cni-args":{"guid":"02:00:00:00:02:00:00:00","mellanox.infiniband.app":"configured"}}]`,
+					},
+				},
+			}
+
+			h := NewPodEventHandler()
+			addMap, _ := h.GetResults()
+			addMap.Set("default_test", []*kapi.Pod{pod})
+
+			h.OnDelete(pod)
+
+			_, stillInAdd := addMap.Get("default_test")
+			Expect(stillInAdd).To(BeFalse(),
+				"OnDelete must drop the stale add-retry entry")
+			_, delMap := h.GetResults()
+			deleted, foundInDelete := delMap.Get("default_test")
+			Expect(foundInDelete).To(BeTrue(), "configured pod should be queued for delete")
+			Expect(deleted.([]*kapi.Pod)).To(HaveLen(1))
+		})
+
+		It("OnDelete clears addedPods even when pod never reached 'configured' (failed CNI)", func() {
+			// Failure-mode path: pod was queued via OnAdd, then KubeVirt deleted
+			// the virt-launcher before multus succeeded. cni-args lacks
+			// mellanox.infiniband.app=configured and network-status was never
+			// written. The deleteFromNetworkAnnotation + deleteFromNetworkStatus
+			// paths both skip this pod, but the addedPods entry must still be
+			// cleaned — otherwise AddPeriodicUpdate would keep re-issuing
+			// AddGuidsToPKey for a UID that no longer exists, and with
+			// partition-aware plugins re-bind the node to the tenant pkey AFTER
+			// the delete-side reset cleared it.
+			unconfiguredPod := &kapi.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "p1", Namespace: "default", UID: "uid-p1",
+					Annotations: map[string]string{
+						v1.NetworkAttachmentAnnot: `[{"name":"test","namespace":"default","cni-args":{"guid":"02:00:00:00:02:00:00:00"}}]`,
+					},
+				},
+			}
+
+			h := NewPodEventHandler()
+			addMap, _ := h.GetResults()
+			addMap.Set("default_test", []*kapi.Pod{unconfiguredPod})
+
+			h.OnDelete(unconfiguredPod)
+
+			_, stillInAdd := addMap.Get("default_test")
+			Expect(stillInAdd).To(BeFalse(),
+				"OnDelete must clean addedPods even when the pod's annotation is "+
+					"incomplete (failed CNI case) — the broader fix that prevents the "+
+					"partition-rebind race after pod-delete")
+		})
+
+		It("OnDelete preserves sibling pods in the same networkID entry", func() {
+			deletedPod := &kapi.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "p1", Namespace: "default", UID: "uid-p1",
+					Annotations: map[string]string{
+						v1.NetworkAttachmentAnnot: `[{"name":"test","namespace":"default","cni-args":{"guid":"02:00:00:00:02:00:00:00","mellanox.infiniband.app":"configured"}}]`,
+					},
+				},
+			}
+			siblingPod := &kapi.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p2", Namespace: "default", UID: "uid-p2"}}
+
+			h := NewPodEventHandler()
+			addMap, _ := h.GetResults()
+			addMap.Set("default_test", []*kapi.Pod{deletedPod, siblingPod})
+
+			h.OnDelete(deletedPod)
+
+			remaining, ok := addMap.Get("default_test")
+			Expect(ok).To(BeTrue(), "sibling pod must keep the networkID entry alive")
+			Expect(remaining.([]*kapi.Pod)).To(HaveLen(1))
+			Expect(remaining.([]*kapi.Pod)[0].UID).To(Equal(siblingPod.UID))
+		})
+
+		It("On delete PF-mode pod without guid is queued for cleanup", func() {
+			// InfiniBand configured without guid (PF mode) — should be queued
+			pod := &kapi.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				v1.NetworkAttachmentAnnot: `[{"name":"test", "cni-args":{"mellanox.infiniband.app":"configured"}}]`}},
+				Spec: kapi.PodSpec{}}
+
+			podEventHandler := NewPodEventHandler()
+			podEventHandler.OnDelete(pod)
+
+			_, delMap := podEventHandler.GetResults()
+			Expect(len(delMap.Items)).To(Equal(1))
 		})
 	})
 	Context("Multi-network pod support", func() {


### PR DESCRIPTION
## Summary

Adds an optional `FabricClient` interface that extends `SubnetManagerClient` with hooks for IB partition lifecycle (setup/teardown, readiness, NAD-driven cleanup) and node-level IB device discovery. No concrete implementation is included — plugins that don't implement the interface see no behavior change, since the daemon type-asserts at startup and falls back to the legacy GUID/PKey flow.

A reference consumer is the NICo plugin proposed in [#221](https://github.com/Mellanox/ib-kubernetes/pull/221). NICo (NVIDIA's NCX Infrastructure Controller) is a fabric manager whose responsibilities include IB partition lifecycle and exposing fabric inventory (partition state, node IB devices, factory-burned PF GUIDs, etc.) through a public REST API. The plugin uses the new hooks to surface those capabilities to the ib-kubernetes daemon.

## Scope

Targets the **fat-VM topology** used for GPU-IB AI workloads on KubeVirt — exactly one VMI per node per IB partition, where each VMI consumes that node's full set of IB PFs. Multi-pod-per-node-per-partition is an explicit non-goal here; lifting it requires a per-(networkID, nodeName) live-pod refcount and is tracked as a follow-up. The single-pod-per-(node, partition) assumption is documented inline in the relevant doc comments.

## Compatibility

- Plugins that do not implement `FabricClient` see no behavior change.
- The partition-aware code paths are unreachable without (a) a plugin that opts in via type assertion and (b) a NAD that opts in via `ibKubernetesEnabled`.
