### PR TITLE
fix: show target names in make help output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ clean: ; $(info  Cleaning...)	 ## Cleanup everything
 
 .PHONY: help
 help: ## Show this message
-	@grep -E '^[ a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+	@grep -hE '^[ a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 # go-get-tool will 'go get' any package $2 and install it to $1.


### PR DESCRIPTION
grep was prefixing matches with the filename because MAKEFILE_LIST contains multiple files, causing awk to print "Makefile" instead of the target name. Use grep -h to suppress filename prefixes.